### PR TITLE
only build on pushes to master and pull requests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,10 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
we were triggering a build on any push to this repo, modifying to match what we have in other repos to only trigger builds on PRs and pushes to master