### PR TITLE
EMBR-4289 test updates after integration with android

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -24,12 +24,13 @@ Make sure the test apps have the latest local @embrace-io/react-native changes:
     npm run update-local-embrace
     ```
 
-Make sure the test apps are installed on the device/emulator before running tests:
+Make sure the test apps are installed on the device/emulator before running tests. Note that building the debug variant
+of the app may interfere with the tests as the debug menu gets in the way of UI elements:
 
     ```bash
     cd basic-test-app
-    npx expo run:android --variant debug # or release
-    npx expo run:ios --variant debug # or release
+    npx expo run:android --variant release
+    npx expo run:ios --variant release
     ```
 
 Run the test suite:

--- a/integration-tests/basic-test-app/android/app/src/main/AndroidManifest.xml
+++ b/integration-tests/basic-test-app/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:networkSecurityConfig="@xml/network_security_config">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>

--- a/integration-tests/basic-test-app/android/app/src/main/res/xml/network_security_config.xml
+++ b/integration-tests/basic-test-app/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/integration-tests/basic-test-app/android/build.gradle
+++ b/integration-tests/basic-test-app/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = findProperty('android.buildToolsVersion') ?: '34.0.0'
-        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
+        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
         kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'

--- a/integration-tests/basic-test-app/app/(tabs)/index.tsx
+++ b/integration-tests/basic-test-app/app/(tabs)/index.tsx
@@ -6,17 +6,29 @@ import {ThemedText} from "@/components/ThemedText";
 
 import ParallaxScrollView from "@/components/ParallaxScrollView";
 import {endSession} from "@embrace-io/react-native";
-import {generateNestedSpans, generateTestSpans} from "@/helpers/generateSpans";
+import {generateBasicSpan, generateNestedSpans, generateTestSpans} from "@/helpers/generateSpans";
 import {Tracer} from "@opentelemetry/api";
-import {EmbraceNativeTracerProvider} from "@embrace-io/react-native-tracer-provider";
+import {useEmbraceNativeTracerProvider} from "@embrace-io/react-native-tracer-provider";
 
 const HomeScreen = () => {
   const handleEndSession = useCallback(() => {
     endSession();
   }, []);
-  const tracer = useMemo<Tracer>(() => {
-    return new EmbraceNativeTracerProvider().getTracer("span-test", "1.0");
-  }, []);
+
+  const {isLoading, isError, error, tracerProvider} = useEmbraceNativeTracerProvider()
+  const tracer = useMemo<Tracer|undefined>(() => {
+    if (tracerProvider) {
+      return tracerProvider.getTracer("span-test", "1.0");
+    }
+  }, [isLoading, isError, error, tracerProvider]);
+
+  if (isLoading) {
+    return <ThemedText type="subtitle">Loading Tracer Provider</ThemedText>
+  }
+
+  if (isError) {
+    return <ThemedText type="subtitle">{error}</ThemedText>
+  }
 
   return (
     <ParallaxScrollView
@@ -34,11 +46,15 @@ const HomeScreen = () => {
       <ThemedView style={styles.stepContainer}>
         <ThemedText type="subtitle">Span</ThemedText>
         <Button
-          onPress={() => generateTestSpans(tracer)}
+          onPress={() => generateBasicSpan(tracer!)}
+          title={"GENERATE BASIC SPAN"}
+        />
+        <Button
+          onPress={() => generateTestSpans(tracer!)}
           title={"GENERATE TEST SPANS"}
         />
         <Button
-          onPress={() => generateNestedSpans(tracer)}
+          onPress={() => generateNestedSpans(tracer!)}
           title={"GENERATE NESTED SPANS"}
         />
       </ThemedView>

--- a/integration-tests/basic-test-app/app/_layout.tsx
+++ b/integration-tests/basic-test-app/app/_layout.tsx
@@ -2,7 +2,7 @@ import {DarkTheme, DefaultTheme, ThemeProvider} from "@react-navigation/native";
 import {useFonts} from "expo-font";
 import {Stack} from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
-import {useEffect} from "react";
+import {useEffect, useMemo, useState} from "react";
 import "react-native-reanimated";
 import {
   initialize as initEmbrace,
@@ -15,12 +15,14 @@ import {useColorScheme} from "@/hooks/useColorScheme";
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
+  const [embraceSDKLoaded, setEmbraceSDKLoaded] = useState<boolean>(false)
   useEffect(() => {
     const init = async () => {
       const hasStarted = await initEmbrace();
 
       if (hasStarted) {
         endEmbraceAppStartup();
+        setEmbraceSDKLoaded(true);
       }
     };
 
@@ -28,9 +30,13 @@ export default function RootLayout() {
   }, []);
 
   const colorScheme = useColorScheme();
-  const [loaded] = useFonts({
+  const [fontsLoaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
+
+  const loaded = useMemo<boolean>(() => {
+    return embraceSDKLoaded && fontsLoaded;
+  }, [embraceSDKLoaded, fontsLoaded]);
 
   useEffect(() => {
     if (loaded) {

--- a/integration-tests/helpers/embrace_server.ts
+++ b/integration-tests/helpers/embrace_server.ts
@@ -1,15 +1,37 @@
 import {start_mockserver, stop_mockserver} from "mockserver-node";
-import {EmbraceRequestBody, SessionMessage} from "../typings/embrace";
+import {EmbracePayload, ParsedSpanPayload} from "../typings/embrace";
+import {parseSpanPayload} from "./span";
 
 import {mockServerClient} from "mockserver-client";
 
 const PORT = 8877;
 
-const startServer = (trace: boolean) => {
+const startServer = async (trace: boolean) => {
   start_mockserver({
     serverPort: PORT,
     trace,
   });
+
+  // Give the mock server a few seconds to spin up
+  await new Promise(r => setTimeout(r, 5000));
+
+  try {
+    const client =  mockServerClient("localhost", PORT);
+    await client.mockAnyResponse({
+      httpResponse: {
+        "body": "{}",
+        "statusCode": 200,
+      },
+      times: {
+        unlimited: true,
+      }
+    })
+    console.log("setup mock response");
+  } catch (error) {
+    console.log(error);
+  }
+
+  return await new Promise(() => {});
 };
 
 const stopServer = () => {
@@ -22,8 +44,9 @@ const clearServer = async () => {
   return await mockServerClient("localhost", PORT).clear({}, "LOG");
 };
 
-const getSessionMessages = async (delay = 2000): Promise<SessionMessage[]> => {
+const getSpanPayloads = async (delay = 5000): Promise<ParsedSpanPayload[]> => {
   if (delay) {
+    console.log(`waiting ${delay}ms before checking for span payloads`)
     await new Promise(r => setTimeout(r, delay));
   }
 
@@ -31,14 +54,14 @@ const getSessionMessages = async (delay = 2000): Promise<SessionMessage[]> => {
     "localhost",
     PORT,
   ).retrieveRecordedRequests({
-    path: "/v1/log/sessions",
+    path: "/v2/spans",
     method: "POST",
   });
 
   return requests.map(r => {
-    const body = r.body as EmbraceRequestBody;
-    return body.json;
+    const body = r.body as EmbracePayload;
+    return parseSpanPayload(body.json.data);
   });
-};
+}
 
-export {startServer, stopServer, clearServer, getSessionMessages};
+export {startServer, stopServer, clearServer, getSpanPayloads};

--- a/integration-tests/helpers/invoke_embrace_server.ts
+++ b/integration-tests/helpers/invoke_embrace_server.ts
@@ -1,8 +1,7 @@
 import {startServer} from "./embrace_server";
 
 const main = async () => {
-  startServer(true);
-  await new Promise(() => {});
+  await startServer(true);
 };
 
 main();

--- a/integration-tests/helpers/session.ts
+++ b/integration-tests/helpers/session.ts
@@ -1,0 +1,20 @@
+import {driver} from "@wdio/globals";
+
+const endSession = async (manual=true) => {
+  //  2 options for ending the session, not sure which is better either manually by clicking the End Session button
+  //  and triggering the call on the Embrace SDK, or by putting the app into the background for a few seconds
+  if (manual) {
+    const endSession = await driver.$("~END SESSION");
+    // Cannot manually end session while session is <5s long so give a bit of a delay
+    console.log("waiting a few seconds before ending the session manually")
+    await new Promise(r => setTimeout(r, 8000));
+    console.log("ending session manually")
+    await endSession.click();
+  } else {
+    console.log("going into the background for a few seconds")
+    await driver.execute('mobile: backgroundApp', { seconds: 5});
+    console.log("back to foreground")
+  }
+}
+
+export {endSession};

--- a/integration-tests/helpers/span.ts
+++ b/integration-tests/helpers/span.ts
@@ -1,0 +1,96 @@
+import {EmbracePayloadSpans, EmbraceSpanAttribute, EmbraceSpanData, ParsedSpanPayload} from "../typings/embrace";
+
+/**
+ * spans are all included on the same array in the payload, to make testing easier separate them into
+ * categories and sort them
+ */
+const parseSpanPayload = (payload: EmbracePayloadSpans): ParsedSpanPayload => {
+  const userSpans: EmbraceSpanData[] = [];
+  const privateSpans: EmbraceSpanData[] = [];
+  const networkSpans: EmbraceSpanData[] = [];
+  const userSpanSnapshots: EmbraceSpanData[] = [];
+  let sessionSpan: EmbraceSpanData = null;
+
+  payload.spans.forEach(span => {
+    sortSpanAttributes(span.attributes)
+
+    if (span.name === "emb-session") {
+      sessionSpan = span;
+      return;
+    }
+
+    if (getAttributeValue(span, "emb.private") === "true") {
+      privateSpans.push(span);
+      return;
+    }
+
+    const embType = getAttributeValue(span, "emb.type");
+    if (embType  === "perf.network_request") {
+      networkSpans.push(span);
+      return;
+    } else if (embType === "perf") {
+      userSpans.push(span);
+      return;
+    }
+  });
+
+  payload.span_snapshots.forEach(span => {
+    sortSpanAttributes(span.attributes)
+
+    if (getAttributeValue(span, "emb.type") === "perf") {
+      userSpanSnapshots.push(span);
+      return;
+    }
+
+  })
+
+  return {
+    sessionSpan,
+    spanSnapshots: sortSpans(payload.span_snapshots),
+    privateSpans: sortSpans(privateSpans),
+    networkSpans: sortSpans(networkSpans),
+    userSpans: sortSpans(userSpans),
+    userSpanSnapshots: sortSpans(userSpanSnapshots),
+  };
+}
+
+const commonEmbraceSpanAttributes = (span: EmbraceSpanData) : EmbraceSpanAttribute[] => sortSpanAttributes([
+  {
+    key: "emb.private.sequence_id",
+    value: span.attributes.find(attr => attr.key === "emb.private.sequence_id")?.value
+  },
+  {
+    key: "emb.process_identifier",
+    value: span.attributes.find(attr => attr.key === "emb.process_identifier")?.value
+  },
+  {
+    key: "emb.key",
+    value: "true"
+  },
+  {
+    key: "emb.type",
+    value: "perf"
+  }
+]);
+
+const commonEmbraceSpanSnapshotAttributes = () : EmbraceSpanAttribute[] => sortSpanAttributes([
+  {
+    key: "emb.key",
+    value: "true"
+  },
+  {
+    key: "emb.type",
+    value: "perf"
+  }
+]);
+
+const sortSpans = (spans: EmbraceSpanData[]): EmbraceSpanData[] =>
+  spans.sort((a, b) => a.name.localeCompare(b.name));
+
+const sortSpanAttributes = (attributes: EmbraceSpanAttribute[]): EmbraceSpanAttribute[] =>
+  attributes.sort((a, b) => a.key.localeCompare(b.key));
+
+const getAttributeValue = (span: EmbraceSpanData, key: string): string =>
+  span.attributes.find(attr => attr.key === key)?.value || "";
+
+export {parseSpanPayload, getAttributeValue, sortSpanAttributes, commonEmbraceSpanAttributes, commonEmbraceSpanSnapshotAttributes};

--- a/integration-tests/specs/session.test.ts
+++ b/integration-tests/specs/session.test.ts
@@ -1,17 +1,15 @@
-import {driver} from "@wdio/globals";
-
-import {getSessionMessages} from "../helpers/embrace_server";
+import {getSpanPayloads} from "../helpers/embrace_server";
+import {endSession} from "../helpers/session";
+import {getAttributeValue} from "../helpers/span";
 
 describe("Sessions", () => {
   it("should be recorded as foreground", async () => {
-    const endSession = await driver.$("~END SESSION");
-    await endSession.click();
+    await endSession();
+    const spanPayloads = await getSpanPayloads();
 
-    const sessionPayloads = await getSessionMessages();
-
-    expect(sessionPayloads).toHaveLength(1);
-    if (sessionPayloads.length > 0) {
-      expect(sessionPayloads[0].s.as).toBe("foreground");
+    expect(spanPayloads).toHaveLength(1);
+    if (spanPayloads.length > 0) {
+      expect(getAttributeValue(spanPayloads[0].sessionSpan, "emb.state")).toBe("foreground");
     }
   });
 });

--- a/integration-tests/specs/tracer_provider.test.ts
+++ b/integration-tests/specs/tracer_provider.test.ts
@@ -1,193 +1,269 @@
 import {driver} from "@wdio/globals";
 
-import {getSessionMessages} from "../helpers/embrace_server";
+import {endSession} from "../helpers/session";
+import {getSpanPayloads} from "../helpers/embrace_server";
 import {EmbraceSpanData} from "../typings/embrace";
+import {commonEmbraceSpanAttributes, commonEmbraceSpanSnapshotAttributes, sortSpanAttributes} from "../helpers/span";
+
+const msToNano = (ms: number) => ms * 1000000;
 
 describe("Tracer Provider", () => {
-  const expectValidIDs = (span: EmbraceSpanData) => {
-    expect(span.span_id).toHaveLength(16);
-    expect(span.span_id).not.toEqual("0000000000000000");
-    expect(span.trace_id).toHaveLength(32);
-    expect(span.trace_id).not.toEqual("00000000000000000000000000000000");
+  const expectValidSpans = (spans: EmbraceSpanData[]) => {
+    const reasonableEpochNanos= msToNano(new Date("2024-01-01T00:00:00Z").getTime())
+    spans.forEach(span => {
+      // span and trace ids are not deterministic so just check they aren't invalid
+      expect(span.span_id).toHaveLength(16);
+      expect(span.span_id).not.toEqual("0000000000000000");
+      expect(span.trace_id).toHaveLength(32);
+      expect(span.trace_id).not.toEqual("00000000000000000000000000000000");
+
+      // unless explicitly set start/end times are based on current time so just assert they are reasonable
+      expect(span.start_time_unix_nano).toBeGreaterThan(reasonableEpochNanos);
+      expect(span.end_time_unix_nano).toBeGreaterThan(reasonableEpochNanos);
+    })
   };
+
+  it("should record a basic span", async () => {
+    const generateBasicSpan = await driver.$("~GENERATE BASIC SPAN");
+    await generateBasicSpan.click();
+    await endSession();
+    const spanPayloads = await getSpanPayloads();
+
+    expect(spanPayloads).toHaveLength(1);
+    if (spanPayloads.length > 0) {
+      const spans = spanPayloads[0].userSpans;
+      expect(spans.length).toBe(1);
+      expectValidSpans(spans);
+      const span = spans[0]
+
+      expect(span).toEqual(
+        {
+          trace_id: span.trace_id,
+          span_id: span.span_id,
+          parent_span_id: "0000000000000000",
+          name: "test-1",
+          start_time_unix_nano: span.start_time_unix_nano,
+          end_time_unix_nano: span.end_time_unix_nano,
+          status: "Unset",
+          events: [],
+          attributes: commonEmbraceSpanAttributes(span),
+        });
+    }
+  });
 
   it("should record test spans", async () => {
     const generateTestSpans = await driver.$("~GENERATE TEST SPANS");
     await generateTestSpans.click();
+    await endSession();
+    const spanPayloads = await getSpanPayloads();
 
-    const endSession = await driver.$("~END SESSION");
-    await endSession.click();
-
-    const sessionPayloads = await getSessionMessages();
-
-    expect(sessionPayloads).toHaveLength(1);
-    if (sessionPayloads.length > 0) {
-      const spans = sessionPayloads[0].spans;
-      expect(spans.length).toBe(3);
-
-      // span and trace ids are not deterministic so just check they aren't invalid
-      expectValidIDs(spans[0]);
-      expectValidIDs(spans[1]);
-      expectValidIDs(spans[2]);
-
-      // TODO update when testing against the actual Embrace SDK
-      const expectedSpanDurations = [2591701, 2352861857268000, 5927541];
-
-      expect(sessionPayloads[0].spans).toEqual([
+    expect(spanPayloads).toHaveLength(1);
+    if (spanPayloads.length > 0) {
+      const spans = spanPayloads[0].userSpans;
+      expect(spans.length).toBe(4);
+      expectValidSpans(spans);
+      expect(spans).toEqual([
         {
           trace_id: spans[0].trace_id,
           span_id: spans[0].span_id,
           parent_span_id: "0000000000000000",
           name: "test-1-updated",
-          start_time_unix_nano: 1718045981827000 * 1000000,
-          end_time_unix_nano:
-            1718045981827000 * 1000000 + expectedSpanDurations[0],
-          status: "OK",
+          start_time_unix_nano: spans[0].start_time_unix_nano,
+          end_time_unix_nano: spans[0].end_time_unix_nano,
+          status: "Ok",
           events: [],
-          attributes: {},
+          attributes: sortSpanAttributes([
+            {
+              key: "string-attr",
+              value: "my-attr",
+            },
+            {
+              key: "number-attr",
+              value: "22.0",
+            },
+            {
+              key: "bool-attr",
+              value: "true",
+            },
+            ...commonEmbraceSpanAttributes(spans[0])
+          ])
         },
         {
           trace_id: spans[1].trace_id,
           span_id: spans[1].span_id,
           parent_span_id: "0000000000000000",
           name: "test-2",
-          start_time_unix_nano: 1718045981828000 * 1000000,
-          end_time_unix_nano:
-            1718045981828000 * 1000000 + expectedSpanDurations[1],
-          status: "UNSET",
+          start_time_unix_nano: spans[1].start_time_unix_nano,
+          end_time_unix_nano: msToNano(new Date("2099-01-01T00:00:00Z").getTime()),
+          status: "Unset",
           events: [
             {
               name: "test-2-event-1",
-              attributes: {},
-              time_unix_nano: 1718045981 * 1000000,
+              attributes: [],
+              time_unix_nano:  spans[1].events[0].time_unix_nano,
             },
             {
               name: "test-2-event-2",
-              attributes: {},
-              time_unix_nano: 1700001002 * 1000000,
+              attributes: [],
+              time_unix_nano: 1700001002000 * 1000000,
             },
             {
               name: "test-2-event-3",
-              attributes: {
-                "test-2-event-attr": "my-event-attr",
-              },
-              time_unix_nano: 1700009002 * 1000000,
+              attributes: [
+                {
+                  key: "test-2-event-attr",
+                  value: "my-event-attr",
+                }
+              ],
+              time_unix_nano: 1700009002000 * 1000000,
             },
           ],
-          attributes: {},
+          attributes: commonEmbraceSpanAttributes(spans[1]),
         },
         {
           trace_id: spans[2].trace_id,
           span_id: spans[2].span_id,
           parent_span_id: "0000000000000000",
           name: "test-3",
-          start_time_unix_nano: 1718045981828000 * 1000000,
-          end_time_unix_nano:
-            1718045981828000 * 1000000 + expectedSpanDurations[2],
-          status: "UNSET",
+          start_time_unix_nano: spans[2].start_time_unix_nano,
+          end_time_unix_nano: spans[2].end_time_unix_nano,
+          status: "Unset",
           events: [
             {
               name: "exception",
-              attributes: {
-                "exception.message": "span exception",
-              },
-              time_unix_nano: 1718045981 * 1000000,
+              attributes: [
+                {
+                  key: "exception.message",
+                  value: "span exception",
+                },
+              ],
+              time_unix_nano: spans[2].events[0].time_unix_nano,
             },
           ],
-          attributes: {},
+          attributes: commonEmbraceSpanAttributes(spans[2]),
+        },
+        {
+          trace_id: spans[3].trace_id,
+          span_id: spans[3].span_id,
+          parent_span_id: "0000000000000000",
+          name: "test-4",
+          start_time_unix_nano: spans[3].start_time_unix_nano,
+          end_time_unix_nano: msToNano(new Date("2024-03-03T00:00:00Z").getTime()),
+          status: "Unset",
+          events: [],
+          attributes: commonEmbraceSpanAttributes(spans[3]),
         },
       ] as EmbraceSpanData[]);
+
+      const snapshots = spanPayloads[0].userSpanSnapshots;
+      expect(snapshots.length).toBe(1);
+      expectValidSpans(snapshots);
+      expect(snapshots).toEqual([
+        {
+          trace_id: snapshots[0].trace_id,
+          span_id: snapshots[0].span_id,
+          parent_span_id: "0000000000000000",
+          name: "test-5",
+          start_time_unix_nano: snapshots[0].start_time_unix_nano,
+          end_time_unix_nano: snapshots[0].end_time_unix_nano,
+          status: "Unset",
+          events: [],
+          attributes: commonEmbraceSpanSnapshotAttributes(),
+        },
+      ] as EmbraceSpanData[]);
+
     }
   });
 
   it("should record nested spans", async () => {
     const generateTestSpans = await driver.$("~GENERATE NESTED SPANS");
     await generateTestSpans.click();
+    await endSession();
+    const spanPayloads = await getSpanPayloads();
 
-    const endSession = await driver.$("~END SESSION");
-    await endSession.click();
-
-    const sessionPayloads = await getSessionMessages();
-
-    expect(sessionPayloads).toHaveLength(1);
-    if (sessionPayloads.length > 0) {
-      const spans = sessionPayloads[0].spans;
-      expect(spans.length).toBe(5);
-
-      // span and trace ids are not deterministic so just check they aren't invalid
-      expectValidIDs(spans[0]);
-      expectValidIDs(spans[1]);
-      expectValidIDs(spans[2]);
-      expectValidIDs(spans[3]);
-      expectValidIDs(spans[4]);
-
-      // TODO update when testing against the actual Embrace SDK
-      const expectedSpanDurations = [46207, 2606099, 693721, 756168, 841156];
-
-      expect(sessionPayloads[0].spans).toEqual([
+    expect(spanPayloads).toHaveLength(1);
+    if (spanPayloads.length > 0) {
+      const spans = spanPayloads[0].userSpans;
+      expect(spans.length).toBe(6);
+      expectValidSpans(spans);
+      expect(spans).toEqual([
         {
           trace_id: spans[0].trace_id,
           span_id: spans[0].span_id,
-          parent_span_id: spans[1].span_id,
-          name: "test-5",
-          start_time_unix_nano: 1718047385968000 * 1000000,
-          end_time_unix_nano:
-            1718047385968000 * 1000000 + expectedSpanDurations[0],
-          status: "UNSET",
+          parent_span_id: "0000000000000000",
+          name: "test-1",
+          start_time_unix_nano: spans[0].start_time_unix_nano,
+          end_time_unix_nano: spans[0].end_time_unix_nano,
+          status: "Unset",
           events: [],
-          attributes: {},
+          attributes: commonEmbraceSpanAttributes(spans[0]),
         },
         {
           trace_id: spans[1].trace_id,
           span_id: spans[1].span_id,
-          parent_span_id: "0000000000000000",
-          name: "test-4",
-          start_time_unix_nano: 1718047385966000 * 1000000,
-          end_time_unix_nano:
-            1718047385966000 * 1000000 + expectedSpanDurations[1],
-          status: "UNSET",
+          parent_span_id: spans[0].span_id, // parent should be test-1
+          name: "test-2",
+          start_time_unix_nano: spans[1].start_time_unix_nano,
+          end_time_unix_nano: spans[1].end_time_unix_nano,
+          status: "Unset",
           events: [],
-          attributes: {},
+          attributes: sortSpanAttributes([
+            {
+              key: "test-2-attr",
+              value: "my-attr",
+            },
+            ...commonEmbraceSpanAttributes(spans[1])
+          ]),
         },
         {
           trace_id: spans[2].trace_id,
           span_id: spans[2].span_id,
           parent_span_id: "0000000000000000",
-          name: "test-1",
-          start_time_unix_nano: 1718047075563000 * 1000000,
-          end_time_unix_nano:
-            1718047075563000 * 1000000 + expectedSpanDurations[2],
-          status: "UNSET",
+          name: "test-3",
+          start_time_unix_nano: spans[2].start_time_unix_nano,
+          end_time_unix_nano: spans[2].end_time_unix_nano,
+          status: "Unset",
           events: [],
-          attributes: {},
+          attributes: sortSpanAttributes([
+            {
+              key: "test-3-attr",
+              value: "my-attr",
+            },
+            ...commonEmbraceSpanAttributes(spans[2])
+          ]),
         },
         {
           trace_id: spans[3].trace_id,
           span_id: spans[3].span_id,
-          parent_span_id: spans[2].span_id,
-          name: "test-2",
-          start_time_unix_nano: 1718047075563000 * 1000000,
-          end_time_unix_nano:
-            1718047075563000 * 1000000 + expectedSpanDurations[3],
-          status: "UNSET",
+          parent_span_id: "0000000000000000",
+          name: "test-4",
+          start_time_unix_nano: spans[3].start_time_unix_nano,
+          end_time_unix_nano: spans[3].end_time_unix_nano,
+          status: "Unset",
           events: [],
-          attributes: {
-            "test-2-attr": "my-attr",
-          },
+          attributes: commonEmbraceSpanAttributes(spans[3]),
         },
         {
           trace_id: spans[4].trace_id,
           span_id: spans[4].span_id,
-          parent_span_id: "0000000000000000",
-          name: "test-3",
-          start_time_unix_nano: 1718047075564000 * 1000000,
-          end_time_unix_nano:
-            1718047075564000 * 1000000 + expectedSpanDurations[4],
-          status: "UNSET",
+          parent_span_id: spans[3].span_id, // parent should be test-4
+          name: "test-5",
+          start_time_unix_nano: spans[4].start_time_unix_nano,
+          end_time_unix_nano: spans[4].end_time_unix_nano,
+          status: "Unset",
           events: [],
-          attributes: {
-            "test-3-attr": "my-attr",
-          },
+          attributes: commonEmbraceSpanAttributes(spans[4]),
+        },
+        {
+          trace_id: spans[5].trace_id,
+          span_id: spans[5].span_id,
+          parent_span_id: "0000000000000000", // test-1 already ended so blank parent ID
+          name: "test-6",
+          start_time_unix_nano: spans[5].start_time_unix_nano,
+          end_time_unix_nano: spans[5].end_time_unix_nano,
+          status: "Unset",
+          events: [],
+          attributes: commonEmbraceSpanAttributes(spans[5]),
         },
       ] as EmbraceSpanData[]);
     }

--- a/integration-tests/typings/embrace.d.ts
+++ b/integration-tests/typings/embrace.d.ts
@@ -1,15 +1,18 @@
 // Types here are a very simplified subset of the full Embrace SDK payload,
 // add more properties as they become relevant for test specs, see:
-// https://github.com/embrace-io/embrace-android-sdk/tree/master/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/payload
+// https://github.com/embrace-io/embrace-android-sdk/blob/master/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Envelope.kt
+// https://github.com/embrace-io/embrace-android-sdk/blob/master/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/SessionPayload.kt
+// https://github.com/embrace-io/embrace-android-sdk/blob/master/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/payload/Span.kt
 
-interface Session {
-  as: string; // appState
+interface EmbraceSpanAttribute {
+  key: string;
+  value: string;
 }
 
 interface EmbraceSpanEvent {
   name: string;
   time_unix_nano: number;
-  attributes: Record<string, string>;
+  attributes: EmbraceSpanAttribute[];
 }
 
 interface EmbraceSpanData {
@@ -19,24 +22,48 @@ interface EmbraceSpanData {
   name: string;
   start_time_unix_nano: number;
   end_time_unix_nano: number;
-  status: "UNSET" | "OK" | "ERROR";
+  status: "Unset" | "Ok" | "Error";
   events: EmbraceSpanEvent[];
-  attributes: Record<string, string>;
+  attributes: EmbraceSpanAttribute[];
 }
 
-interface SessionMessage {
-  s: Session;
+interface EmbracePayloadSpans {
   spans: EmbraceSpanData[];
+  span_snapshots: EmbraceSpanData[];
 }
 
-interface EmbraceRequestBody {
-  json: SessionMessage;
+interface EmbracePayloadResource {
+  // TODO
+}
+
+interface EmbracePayloadMetadata {
+  // TODO
+}
+
+interface ParsedSpanPayload {
+  sessionSpan: EmbraceSpanData,
+  spanSnapshots: EmbraceSpanData[],
+  privateSpans: EmbraceSpanData[],
+  networkSpans: EmbraceSpanData[],
+  userSpans: EmbraceSpanData[],
+  userSpanSnapshots: EmbraceSpanData[],
+}
+
+interface EmbracePayload {
+  json: {
+    resource: EmbracePayloadResource
+    metadata: EmbracePayloadMetadata
+    version: string,
+    type: "spans", // TODO logs
+    data: EmbracePayloadSpans, // TODO logs
+  }
 }
 
 export type {
-  EmbraceRequestBody,
-  SessionMessage,
-  Session,
+  EmbracePayload,
+  EmbracePayloadSpans,
   EmbraceSpanData,
+  EmbraceSpanAttribute,
   EmbraceSpanEvent,
+  ParsedSpanPayload,
 };

--- a/integration-tests/wdio.conf.ts
+++ b/integration-tests/wdio.conf.ts
@@ -3,7 +3,8 @@ import {
   clearServer,
   startServer,
   stopServer,
-} from "./helpers/embrace_server.ts";
+} from "./helpers/embrace_server";
+
 
 export const config: Options.Testrunner = {
   //
@@ -33,7 +34,7 @@ export const config: Options.Testrunner = {
   // worker process. In order to have a group of spec files run in the same worker
   // process simply enclose them in an array within the specs array.
   //
-  // The path of the spec files will be resolved relative from the directory of
+  // The path of the spec files will be resolved relative from the directory
   // of the config file unless it's absolute.
   //
   specs: ["./specs/**/*.ts"],
@@ -72,7 +73,6 @@ export const config: Options.Testrunner = {
       "appium:automationName": "UiAutomator2",
       "appium:appPackage": "io.embrace.basictestapp",
       "appium:appActivity": ".MainActivity",
-      "appium:noReset": true,
 
       //  TODO: for CI/CD we probably want to point to the prebuilt release
       //  APK rather than having to have the app running in an emulator beforehand, e.g.


### PR DESCRIPTION
A few changes to the integration tests after testing with the actual Android SDK:
* newest version is sending payloads to v2/spans and not the only session endpoint so update types there
* update test expectations around the spans to reflect how they actual behave in the SDK