### PR TITLE
EMBR-4625 handle removing session properties for all lifespans

### DIFF
--- a/packages/core/ios/RNEmbrace/EmbraceManager.swift
+++ b/packages/core/ios/RNEmbrace/EmbraceManager.swift
@@ -262,8 +262,11 @@ class EmbraceManager: NSObject {
     @objc(removeSessionProperty:resolver:rejecter:)
     func removeSessionProperty(_ key: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         do {
-            // TODO REfactor to include lifespan
-            try Embrace.client?.metadata.removeProperty(key: key)
+            // Depending on on how `addSessionProperty` was called we may have added this key as either
+            // .session or .permanent so remove both here, multiple calls to remove are safe
+            try Embrace.client?.metadata.removeProperty(key: key, lifespan: .permanent)
+            try Embrace.client?.metadata.removeProperty(key: key, lifespan: .session)
+            
             resolve(true)
         } catch let error {
             reject("REMOVE_SESSION_PROPERTY", "Error removing Session Property", error)


### PR DESCRIPTION
No API exposed by the iOS SDK currently for removing properties from all lifespans, however it is safe to call `removeProperty` multiple times ourselves to make sure we've gotten rid of the property we've added