### PR TITLE
Rn 4.3.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "4.2.0",
+  "version": "4.3.0",
   "npmClient": "yarn"
 }

--- a/packages/action-tracker/package.json
+++ b/packages/action-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-action-tracker",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Allows tracking the dispatched actions of your state management using the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-apollo-graphql",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "This is used to track networks calls using GraphQL with the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/core/android/gradle.properties
+++ b/packages/core/android/gradle.properties
@@ -1,1 +1,1 @@
-emb_android_sdk=6.8.2
+emb_android_sdk=6.12.1

--- a/packages/core/android/gradle.properties
+++ b/packages/core/android/gradle.properties
@@ -1,1 +1,1 @@
-emb_android_sdk=6.12.1
+emb_android_sdk=6.13.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native",
-  "version": "4.3.0",
+  "version": "4.2.1",
   "description": "A React Native wrapper for the Embrace SDK",
   "dependencies": {
     "glob": "^7.1.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "A React Native wrapper for the Embrace SDK",
   "dependencies": {
     "glob": "^7.1.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A React Native wrapper for the Embrace SDK",
   "dependencies": {
     "glob": "^7.1.4",
@@ -15,8 +15,14 @@
   },
   "files": [
     "lib",
-    "android",
-    "ios",
+    "android/src",
+    "android/build.gradle",
+    "android/gradle.properties",
+    "ios/RNEmbrace/EmbraceManager.h",
+    "ios/RNEmbrace/EmbraceManager.m",
+    "ios/RNEmbrace/EmbraceOTelSpanHelper.h",
+    "ios/RNEmbrace/EmbraceOTelSpanHelper.m",
+    "ios/RNEmbrace.xcodeproj",
     "RNEmbrace.podspec"
   ],
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",

--- a/packages/react-native-navigation/package.json
+++ b/packages/react-native-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-navigation",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "This is used to track React Native screens (using React Native Navigation) with the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/react-navigation/package.json
+++ b/packages/react-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-navigation",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "This is used to track React Native screens with the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/screen-orientation/package.json
+++ b/packages/screen-orientation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-orientation-change-tracker",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Allows tracking the App orientation using the Embrace SDK",
   "peerDependencies": {
     "react-native": ">=0.56.0"

--- a/packages/spans/package.json
+++ b/packages/spans/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-spans",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Embrace’s Performance Tracing solution gives you complete visibility into any customized operation you’d like to track, enabling you to identify, prioritize, and resolve any performance issue",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/webview-tracker/package.json
+++ b/packages/webview-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-webview-tracker",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Allows tracking events on WebView components using the Embrace SDK",
   "peerDependencies": {
     "react-native": ">=0.56.0"


### PR DESCRIPTION
Update the Android SDK to 6.12.1 since this includes the refactor for source map and bundle uploads. This update also includes using MD5 instead of the native build ID.

Extra: I added some files to the package.json to exclude some files from the final package

To test.

- cd packages/core
- yarn pack
- Copy the TZ's path
- Go to your testapp and run `yarn add tzPath`
- Run the install script commands
- Run the app
