### PR TITLE
EMBR-5336 fix fs error handling in install scripts

### DIFF
--- a/packages/core/scripts/setup/android.ts
+++ b/packages/core/scripts/setup/android.ts
@@ -92,8 +92,12 @@ export const createEmbraceJSON = {
         fs.closeSync(fs.openSync(p, "ax"));
         return resolve(embraceJSON());
       } catch (e) {
-        logger.log("already has embrace-config.json file");
-        return resolve(NoopFile);
+        if (e instanceof Error && e.message.includes("EEXIST")) {
+          logger.log("already has embrace-config.json file");
+          return resolve(NoopFile);
+        } else {
+          throw e;
+        }
       }
     }).then((file: FileUpdatable) => {
       if (file === NoopFile) {

--- a/packages/core/scripts/setup/ios.ts
+++ b/packages/core/scripts/setup/ios.ts
@@ -152,8 +152,12 @@ export const addEmbraceInitializerSwift = {
       const fd = fs.openSync(filePath, "wx");
       fs.writeFileSync(fd, getEmbraceInitializerContents(appId));
     } catch (e) {
-      logger.warn("EmbraceInitializer.swift already exists");
-      return;
+      if (e instanceof Error && e.message.includes("EEXIST")) {
+        logger.warn("EmbraceInitializer.swift already exists");
+        return;
+      } else {
+        throw e;
+      }
     }
 
     const nameWithCaseSensitive = findNameWithCaseSensitiveFromPath(


### PR DESCRIPTION
I introduced this in https://github.com/embrace-io/embrace-react-native-sdk/pull/197 and the error handling was assuming that if `fs.openSync` threw an error it was because the file already exists, but there are other cases possible (like parent directory missing) so adding an extra check here