### PR TITLE
EMBR-5134 update READMEs to include test harness and app templates

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -30,96 +30,19 @@ that our packages require but that we leave to the customer to have defined as e
 From the root of the project you can lint and test all packages with:
 
 ```bash
-yarn lint
-yarn test
+yarn lint:js # or lint:swift for native changes
+yarn test # or android:test or ios:test for native changes
 ```
 
-## Manual integration testing (TODO update after changes to integration testing workflow)
+## Integration testing
 
-The [example app](examples/react-native-test-suite/) allows you to test out the React Native Embrace SDK in a representative app.
-
-Code changes will **NOT** automatically be picked up by the example app. You **MUST** follow the instructions to test out local changes.
-
-To get started generate a new artifact from whichever packages you modified:
-
-```bash
-cd packages/<package-modified>/
-yarn build
-npm pack    # yarn pack behaves differently, stick to npm pack because that's what lerna publish uses
-```
-
-Then update the example app with that local artifact:
-
-```bash
-cd examples/react-native-test-suite
-yarn add ../<path-to-local-artifact>/
-```
-
-If you alter the node_modules in any way (either by deleting them or running `yarn install`) or make further changes
-then you will need to follow the above instructions again.
-
-Then run the app on either Android or iOS, note that React Native behaves substantially different between debug/release
-mode, so we should always test release candidates against a release build.
-
-Android:
-
-```bash
-`yarn android --mode=release`
-```
-
-iOS:
-
-```bash
-pushd ios; pod install; popd;
-yarn ios --mode=Release
-```
-
-## Testing against new Embrace Android SDK versions (TODO update after changes to integration testing workflow)
-
-You can test Embrace Android SDK changes by altering the dependency in the core package's [build.gradle](./packages/core/android/build.gradle).
-And then either publish a local artifact or if you need CI to pass - publish a beta:
-
-### Local artifact
-
-1. Publish locally with `cd packages/core/android && ./gradlew clean assembleRelease publishToMavenLocal -Pversion=<your-version-here>`
-2. Add `mavenLocal()` to the `repositories` closure in `examples/react-native-test-suite/node_modules/embrace-io/android/build.gradle`
-3. Set the correct `embrace-android-sdk` version in `examples/react-native-test-suite/node_modules/embrace-io/android/build.gradle`
-4. Run the app in the normal way
-
-### Beta artifact
-
-1. Follow the [Android repo](https://github.com/embrace-io/embrace-android-sdk3#qa-releases) instructions for creating a beta
-2. Find `rootProject.allprojects.repositories` in `embrace_android/android/build.gradle` and add `maven {url "https://repo.embrace.io/repository/beta"}`
-3. Add `mavenLocal()` to the `repositories` closure in `examples/react-native-test-suite/node_modules/embrace-io/android/build.gradle`
-4. Set the correct `embrace-android-sdk` version in `examples/react-native-test-suite/node_modules/embrace-io/android/build.gradle`
-5. Run the app in the normal way
-
-## Testing against new Embrace iOS SDK versions (TODO update after changes to integration testing workflow)
-
-### Local artifact
-
-You can test local changes to the iOS SDK by updating the example app's `podspec` and `Podfile` to point to the local copy.
-
-1. In `examples/react-native-test-suite/node_modules/embrace-io/RNEmbrace.podspec`, change the dependency on the iOS SDK to `s.dependency 'EmbraceIO-LOCAL'`
-2. In `examples/react-native-test-suite/ios/Podfile`, add the following line `pod 'EmbraceIO-LOCAL', :path => 'path/to/ios_sdk'`
-3. In `examples/react-native-test-suite/ios`, run the `pod update` command
-
-### Beta artifact
-
-1. Ask the iOS team to publish a beta of the iOS SDK to the `EmbraceIO-DEV` pod
-2. In `examples/react-native-test-suite/node_modules/embrace-io/RNEmbrace.podspec`, change the dependency on the iOS SDK to `s.dependency 'EmbraceIO-DEV'`
-3. In `examples/react-native-test-suite/ios/Podfile`, add the following line `pod 'EmbraceIO-DEV'`
-4. In `examples/react-native-test-suite/ios`, run the `pod update` command
+See the [integration testing README](./integration-tests/README.md) for more details.
 
 ## Updating native SDK dependencies
 
 1. Bump the Android (SDK + Swazzler)/iOS dependencies to the latest available stable versions in `./yarn.config.cjs`
 2. Run `yarn constraints --fix` to propagate this change to all package.json files
 3. Run `yarn build` to update build files to the latest versions
-
-## Automated integration testing
-
-Automated integration testing is being actively developed to replace some of the manual testing outlined above, see [here](./integration-tests/README.md) for more details.
 
 ## Branching strategy
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -122,10 +122,10 @@ launched for the suite run so that requests sent from the device can be inspecte
 Follow the steps from "Build and install on device" above to have an app running on an emulator with the Embrace test
 harness and pointing to the local node mock server.
 
-TODO
+Run the integration tests specifying the package name of app being tested
 
 ```bash
-npm test
+npm test -- --package=foobar --platform=android # ios, both
 ```
 
 ### CI

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -46,7 +46,7 @@ instead you can run a different version of the `create-expo` package.
 New test apps can be created from templates as needed. To create a new bare react native app run:
 
 ```bash
-npx @react-native-community/cli init <test-app> --package-name io.embrace.<test-app> --skip-git-init --skip-install --pm yarn --template $(pwd)/templates/react-native-test-app-template
+npx @react-native-community/cli init <testApp> --package-name io.embrace.<test-app> --skip-git-init --skip-install --pm yarn --template $(pwd)/templates/<template-name>
 ```
 
 To create a new test expo app run:


### PR DESCRIPTION
Probably best to read `integration-tests/README.md` as a rendered page

Will tackle Browserstack hook up next so likely the way we run integration tests will get updated again