### PR TITLE
make a dependabot group for babel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
       eslint:
         patterns:
           - '*eslint*'
+      babel:
+        patterns:
+          - '@babel*'


### PR DESCRIPTION
This week we had PRs for:
* @babel/preset-env
* @babel/preset-react
* @babel/core
* @babel/preset-typescript 

Probably makes sense to treat these all as a group