### PR TITLE
EMBR-5586 do version bump before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "publish-modules": "npx lerna run build && npx lerna publish",
+    "publish-modules": "npx lerna version && npx lerna run build && npx lerna publish from-git",
     "prebuild": "npx lerna run prebuild",
     "build": "npx lerna run build",
     "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx && prettier \"packages/**/*.{js,jsx,ts,tsx,json}\" && yarn constraints",


### PR DESCRIPTION
I *think* this will do the right thing based on reading: https://github.com/lerna/lerna/tree/main/libs/commands/publish, the idea is to first run `lerna version` so that all the package.json files have the correct next version *then* build each package which should mean that the core package specifically has the right version built into `lib/package.json`. After that we do `lerna publish from-git` which unlike the base command doesn't try and run `version` again.

I didn't try and fully test this I think the easiest way to verify might be to just to run through this workflow next time we release and see if it works as expected. It might be that `from-package` is the option we want, it also skips the version step but does a different check