### PR TITLE
Jpmunz/embr 5801 possible unhandled exceptions

### DIFF
--- a/packages/core/src/EmbraceManagerModule.ts
+++ b/packages/core/src/EmbraceManagerModule.ts
@@ -1,0 +1,18 @@
+import {NativeModules, Platform} from "react-native";
+
+const LINKING_ERROR =
+  `The package '@embrace-io/react-native' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ios: "- You have run 'pod install'\n", default: ""}) +
+  "- You rebuilt the app after installing the package\n" +
+  "- You are not using Expo Go\n";
+
+export const EmbraceManagerModule = NativeModules.EmbraceManager
+  ? NativeModules.EmbraceManager
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      },
+    );

--- a/packages/core/src/__tests__/embrace.test.ts
+++ b/packages/core/src/__tests__/embrace.test.ts
@@ -59,90 +59,88 @@ const mockGetLastRunEndState = jest.fn();
 const mockGetDeviceId = jest.fn();
 const mockGetCurrentSessionId = jest.fn();
 
-jest.mock("react-native", () => ({
-  NativeModules: {
-    EmbraceManager: {
-      setUserIdentifier: (userIdentifier: string) =>
-        mockSetUserIdentifier(userIdentifier),
-      clearUserIdentifier: () => mockClearUserIdentifier(),
-      setUsername: (username: string) => mockSetUsername(username),
-      clearUsername: () => mockClearUsername(),
-      setUserEmail: (userEmail: string) => mockSetUserEmail(userEmail),
-      clearUserEmail: () => mockClearUserEmail(),
-      addBreadcrumb: (message: string) => mockAddBreadcrumb(message),
-      logMessageWithSeverityAndProperties: (
-        message: string,
-        severity: string,
-        properties: Properties,
-        stacktrace: string,
-      ) =>
-        mockLogMessageWithSeverityAndProperties(
-          message,
-          severity,
-          properties,
-          stacktrace,
-        ),
-      logHandledError: (
-        message: string,
-        stackTrace: string,
-        properties?: Properties,
-      ) => mockLogHandledError(message, stackTrace, properties),
-      addUserPersona: (persona: string) => mockAddUserPersona(persona),
-      clearUserPersona: (persona: string) => mockClearUserPersona(persona),
-      clearAllUserPersonas: () => mockClearAllUserPersonas(),
-      startView: (view: string) => mockStartView(view),
-      endView: (view: string) => mockEndView(view),
-      addSessionProperty: (key: string, value: string, permanent: boolean) =>
-        mockAddSessionProperty(key, value, permanent),
-      removeSessionProperty: (key: string) => mockRemoveSessionProperty(key),
-      setUserAsPayer: () => {
-        mockSetUserAsPayer();
-        return false;
-      },
-      clearUserAsPayer: () => {
-        mockClearUserAsPayer();
-        return false;
-      },
-      setJavaScriptBundlePath: (path: string) =>
-        mockSetJavaScriptBundlePath(path),
-      logNetworkRequest: (
-        url: string,
-        httpMethod: MethodType,
-        startInMillis: number,
-        endInMillis: number,
-        bytesSent: number,
-        bytesReceived: number,
-        statusCode: number,
-      ) =>
-        mockLogNetworkRequest(
-          url,
-          httpMethod,
-          startInMillis,
-          endInMillis,
-          bytesSent,
-          bytesReceived,
-          statusCode,
-        ),
-      logNetworkClientError: (
-        url: string,
-        httpMethod: MethodType,
-        startInMillis: number,
-        endInMillis: number,
-        errorType: string,
-        errorMessage: string,
-      ) =>
-        mockLogNetworkClientError(
-          url,
-          httpMethod,
-          startInMillis,
-          endInMillis,
-          errorType,
-          errorMessage,
-        ),
-      getLastRunEndState: () => mockGetLastRunEndState(),
-      getDeviceId: () => mockGetDeviceId(),
-      getCurrentSessionId: () => mockGetCurrentSessionId(),
+jest.mock("../EmbraceManagerModule", () => ({
+  EmbraceManagerModule: {
+    setUserIdentifier: (userIdentifier: string) =>
+      mockSetUserIdentifier(userIdentifier),
+    clearUserIdentifier: () => mockClearUserIdentifier(),
+    setUsername: (username: string) => mockSetUsername(username),
+    clearUsername: () => mockClearUsername(),
+    setUserEmail: (userEmail: string) => mockSetUserEmail(userEmail),
+    clearUserEmail: () => mockClearUserEmail(),
+    addBreadcrumb: (message: string) => mockAddBreadcrumb(message),
+    logMessageWithSeverityAndProperties: (
+      message: string,
+      severity: string,
+      properties: Properties,
+      stacktrace: string,
+    ) =>
+      mockLogMessageWithSeverityAndProperties(
+        message,
+        severity,
+        properties,
+        stacktrace,
+      ),
+    logHandledError: (
+      message: string,
+      stackTrace: string,
+      properties?: Properties,
+    ) => mockLogHandledError(message, stackTrace, properties),
+    addUserPersona: (persona: string) => mockAddUserPersona(persona),
+    clearUserPersona: (persona: string) => mockClearUserPersona(persona),
+    clearAllUserPersonas: () => mockClearAllUserPersonas(),
+    startView: (view: string) => mockStartView(view),
+    endView: (view: string) => mockEndView(view),
+    addSessionProperty: (key: string, value: string, permanent: boolean) =>
+      mockAddSessionProperty(key, value, permanent),
+    removeSessionProperty: (key: string) => mockRemoveSessionProperty(key),
+    setUserAsPayer: () => {
+      mockSetUserAsPayer();
+      return false;
     },
+    clearUserAsPayer: () => {
+      mockClearUserAsPayer();
+      return false;
+    },
+    setJavaScriptBundlePath: (path: string) =>
+      mockSetJavaScriptBundlePath(path),
+    logNetworkRequest: (
+      url: string,
+      httpMethod: MethodType,
+      startInMillis: number,
+      endInMillis: number,
+      bytesSent: number,
+      bytesReceived: number,
+      statusCode: number,
+    ) =>
+      mockLogNetworkRequest(
+        url,
+        httpMethod,
+        startInMillis,
+        endInMillis,
+        bytesSent,
+        bytesReceived,
+        statusCode,
+      ),
+    logNetworkClientError: (
+      url: string,
+      httpMethod: MethodType,
+      startInMillis: number,
+      endInMillis: number,
+      errorType: string,
+      errorMessage: string,
+    ) =>
+      mockLogNetworkClientError(
+        url,
+        httpMethod,
+        startInMillis,
+        endInMillis,
+        errorType,
+        errorMessage,
+      ),
+    getLastRunEndState: () => mockGetLastRunEndState(),
+    getDeviceId: () => mockGetDeviceId(),
+    getCurrentSessionId: () => mockGetCurrentSessionId(),
   },
 }));
 

--- a/packages/core/src/__tests__/initialize.test.ts
+++ b/packages/core/src/__tests__/initialize.test.ts
@@ -12,31 +12,32 @@ const mockLogMessageWithSeverityAndProperties = jest.fn();
 
 const ReactNativeMock = jest.requireMock("react-native");
 
-jest.mock("react-native", () => ({
-  NativeModules: {
-    EmbraceManager: {
-      setReactNativeVersion: (version: string) =>
-        mockSetReactNativeVersion(version),
-      setJavaScriptPatchNumber: (patch: string) =>
-        mockSetJavaScriptPatchNumber(patch),
-      setReactNativeSDKVersion: (version: string) =>
-        mockSetReactNativeSDKVersion(version),
-      logMessageWithSeverityAndProperties: (
-        message: string,
-        severity: string,
-        properties: object,
-        stacktrace: string,
-      ) =>
-        mockLogMessageWithSeverityAndProperties(
-          message,
-          severity,
-          properties,
-          stacktrace,
-        ),
-      isStarted: () => mockIsStarted(),
-      startNativeEmbraceSDK: (appId?: string) => mockStart(appId),
-    },
+jest.mock("../EmbraceManagerModule", () => ({
+  EmbraceManagerModule: {
+    setReactNativeVersion: (version: string) =>
+      mockSetReactNativeVersion(version),
+    setJavaScriptPatchNumber: (patch: string) =>
+      mockSetJavaScriptPatchNumber(patch),
+    setReactNativeSDKVersion: (version: string) =>
+      mockSetReactNativeSDKVersion(version),
+    logMessageWithSeverityAndProperties: (
+      message: string,
+      severity: string,
+      properties: object,
+      stacktrace: string,
+    ) =>
+      mockLogMessageWithSeverityAndProperties(
+        message,
+        severity,
+        properties,
+        stacktrace,
+      ),
+    isStarted: () => mockIsStarted(),
+    startNativeEmbraceSDK: (appId?: string) => mockStart(appId),
   },
+}));
+
+jest.mock("react-native", () => ({
   Platform: {OS: "android"},
 }));
 

--- a/packages/core/src/__tests__/initialize.test.ts
+++ b/packages/core/src/__tests__/initialize.test.ts
@@ -1,4 +1,5 @@
-import {handleGlobalError} from "../utils/ErrorUtil";
+import {waitFor} from "@testing-library/react-native";
+
 import {initialize} from "../index";
 
 const testValue = "Value";
@@ -9,6 +10,7 @@ const mockIsStarted = jest.fn();
 const mockStart = jest.fn();
 const mockSetReactNativeSDKVersion = jest.fn();
 const mockLogMessageWithSeverityAndProperties = jest.fn();
+const mockLogUnhandledJSException = jest.fn();
 
 const ReactNativeMock = jest.requireMock("react-native");
 
@@ -32,6 +34,12 @@ jest.mock("../EmbraceManagerModule", () => ({
         properties,
         stacktrace,
       ),
+    logUnhandledJSException: (
+      name: string,
+      message: string,
+      errorType: string,
+      stacktrace: string,
+    ) => mockLogUnhandledJSException(name, message, errorType, stacktrace),
     isStarted: () => mockIsStarted(),
     startNativeEmbraceSDK: (appId?: string) => mockStart(appId),
   },
@@ -94,46 +102,40 @@ describe("Android: initialize", () => {
     );
   });
 
-  test("sdk not already started on iOS, missing app id", async () => {
-    ReactNativeMock.Platform.OS = "ios";
-    mockIsStarted.mockReturnValue(false);
-    const result = await initialize({patch: testValue});
-    expect(result).toBe(false);
-    expect(mockStart).not.toHaveBeenCalled();
-    expect(mockSetReactNativeVersion).not.toHaveBeenCalled();
-    expect(mockSetJavaScriptPatchNumber).not.toHaveBeenCalled();
-    expect(mockSetReactNativeSDKVersion).not.toHaveBeenCalled();
-    expect(mockLogMessageWithSeverityAndProperties).not.toHaveBeenCalled();
-  });
-
-  test("sdk not already started on iOS, app id supplied", async () => {
-    ReactNativeMock.Platform.OS = "ios";
-    mockIsStarted.mockReturnValue(false);
-    const result = await initialize({
-      patch: testValue,
-      sdkConfig: {ios: {appId: "abc12"}},
-    });
-    expect(result).toBe(true);
-    expect(mockStart).toHaveBeenCalledWith({appId: "abc12"});
-    expect(mockLogMessageWithSeverityAndProperties).toHaveBeenCalled();
-    expect(mockLogMessageWithSeverityAndProperties.mock.calls[0][0]).toBe(
-      "Unhandled promise rejection: ",
-    );
-  });
-
-  test("applying previousHandler", async () => {
+  test("applies global error handler", async () => {
     const previousHandler = jest.fn();
-    ErrorUtils.getGlobalHandler = previousHandler;
+    ErrorUtils.setGlobalHandler(previousHandler);
+    mockLogUnhandledJSException.mockReturnValue(Promise.resolve(true));
+
     const result = await initialize({patch: testValue});
     expect(result).toBe(true);
+    const updatedHandler = ErrorUtils.getGlobalHandler();
+    const err = Error("Test");
 
-    const handleError = () => {};
-    const generatedGlobalErrorFunc = handleGlobalError(
-      previousHandler,
-      handleError,
-    );
-    generatedGlobalErrorFunc(Error("Test"));
-    expect(previousHandler).toHaveBeenCalled();
+    updatedHandler(err, true);
+
+    await waitFor(() => {
+      expect(previousHandler).toHaveBeenCalledWith(err, true);
+      expect(mockLogUnhandledJSException).toHaveBeenCalled();
+    });
+  });
+
+  test("global error handler handles logUnhandledJSException rejecting", async () => {
+    const previousHandler = jest.fn();
+    ErrorUtils.setGlobalHandler(previousHandler);
+    mockLogUnhandledJSException.mockRejectedValue("failed");
+
+    const result = await initialize({patch: testValue});
+    expect(result).toBe(true);
+    const updatedHandler = ErrorUtils.getGlobalHandler();
+    const err = Error("Test");
+
+    updatedHandler(err, true);
+
+    await waitFor(() => {
+      expect(previousHandler).toHaveBeenCalledWith(err, true);
+      expect(mockLogUnhandledJSException).toHaveBeenCalled();
+    });
   });
 });
 
@@ -158,5 +160,40 @@ describe("iOS: initialize", () => {
     expect(mockstartCustomExport).toHaveBeenCalledWith({appId: "abc12"});
     expect(mockStart).not.toHaveBeenCalled();
     expect(isStarted).toBe(true);
+  });
+
+  test("sdk not already started, missing app id", async () => {
+    mockIsStarted.mockReturnValue(false);
+    const result = await initialize({patch: testValue});
+    expect(result).toBe(false);
+    expect(mockStart).not.toHaveBeenCalled();
+    expect(mockSetReactNativeVersion).not.toHaveBeenCalled();
+    expect(mockSetJavaScriptPatchNumber).not.toHaveBeenCalled();
+    expect(mockSetReactNativeSDKVersion).not.toHaveBeenCalled();
+    expect(mockLogMessageWithSeverityAndProperties).not.toHaveBeenCalled();
+  });
+
+  test("sdk not already started, app id supplied", async () => {
+    mockIsStarted.mockReturnValue(false);
+    const result = await initialize({
+      patch: testValue,
+      sdkConfig: {ios: {appId: "abc12"}},
+    });
+    expect(result).toBe(true);
+    expect(mockStart).toHaveBeenCalledWith({appId: "abc12"});
+    expect(mockLogMessageWithSeverityAndProperties).toHaveBeenCalled();
+    expect(mockLogMessageWithSeverityAndProperties.mock.calls[0][0]).toBe(
+      "Unhandled promise rejection: ",
+    );
+  });
+
+  test("sdk start call is rejected", async () => {
+    mockStart.mockRejectedValue("failed");
+    mockIsStarted.mockReturnValue(false);
+    const result = await initialize({
+      patch: testValue,
+      sdkConfig: {ios: {appId: "abc12"}},
+    });
+    expect(result).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/network.test.ts
+++ b/packages/core/src/__tests__/network.test.ts
@@ -6,47 +6,48 @@ const mockLogNetworkClientError = jest.fn();
 
 const ReactNativeMock = jest.requireMock("react-native");
 
-jest.mock("react-native", () => ({
-  NativeModules: {
-    EmbraceManager: {
-      logNetworkRequest: (
-        url: string,
-        httpMethod: MethodType,
-        startInMillis: number,
-        endInMillis: number,
-        bytesSent: number,
-        bytesReceived: number,
-        statusCode: number,
-        error: string,
-      ) =>
-        mockLogNetworkRequest(
-          url,
-          httpMethod,
-          startInMillis,
-          endInMillis,
-          bytesSent,
-          bytesReceived,
-          statusCode,
-          error,
-        ),
-      logNetworkClientError: (
-        url: string,
-        httpMethod: MethodType,
-        startInMillis: number,
-        endInMillis: number,
-        errorType: string,
-        errorMessage: string,
-      ) =>
-        mockLogNetworkClientError(
-          url,
-          httpMethod,
-          startInMillis,
-          endInMillis,
-          errorType,
-          errorMessage,
-        ),
-    },
+jest.mock("../EmbraceManagerModule", () => ({
+  EmbraceManagerModule: {
+    logNetworkRequest: (
+      url: string,
+      httpMethod: MethodType,
+      startInMillis: number,
+      endInMillis: number,
+      bytesSent: number,
+      bytesReceived: number,
+      statusCode: number,
+      error: string,
+    ) =>
+      mockLogNetworkRequest(
+        url,
+        httpMethod,
+        startInMillis,
+        endInMillis,
+        bytesSent,
+        bytesReceived,
+        statusCode,
+        error,
+      ),
+    logNetworkClientError: (
+      url: string,
+      httpMethod: MethodType,
+      startInMillis: number,
+      endInMillis: number,
+      errorType: string,
+      errorMessage: string,
+    ) =>
+      mockLogNetworkClientError(
+        url,
+        httpMethod,
+        startInMillis,
+        endInMillis,
+        errorType,
+        errorMessage,
+      ),
   },
+}));
+
+jest.mock("react-native", () => ({
   Platform: {OS: "android"},
 }));
 

--- a/packages/core/src/networkInterceptors/providers/AxiosProvider.ts
+++ b/packages/core/src/networkInterceptors/providers/AxiosProvider.ts
@@ -1,4 +1,4 @@
-import {NativeModules, Platform} from "react-native";
+import {Platform} from "react-native";
 import {zip} from "gzip-js";
 
 import {
@@ -9,6 +9,7 @@ import {
   IAxiosResponse,
   IEmbraceAxiosTrackerMetadata,
 } from "../../interfaces/IAxios";
+import {EmbraceManagerModule} from "../../EmbraceManagerModule";
 
 const UNKNONW_ERROR_MESSAGE =
   "[Embrace] Embrace was unable to capture the errored request due to limitations in the Axios API. Please raise a bug on the Axios repo if this affects you.";
@@ -34,7 +35,7 @@ const logErrorWithResponse = (
   const {startInMillis} = embraceMetadata;
 
   const logIOS = () =>
-    NativeModules.EmbraceManager.logNetworkRequest(
+    EmbraceManagerModule.logNetworkRequest(
       url,
       method,
       startInMillis,
@@ -46,7 +47,7 @@ const logErrorWithResponse = (
     );
 
   const logAndroid = () =>
-    NativeModules.EmbraceManager.logNetworkClientError(
+    EmbraceManagerModule.logNetworkClientError(
       url,
       method,
       startInMillis,
@@ -97,7 +98,7 @@ const applyResponseInterceptors = (
     const {startInMillis} = embraceMetadata;
 
     try {
-      NativeModules.EmbraceManager.logNetworkRequest(
+      EmbraceManagerModule.logNetworkRequest(
         url,
         method,
         startInMillis,

--- a/packages/react-native-tracer-provider/src/TracerProviderModule.ts
+++ b/packages/react-native-tracer-provider/src/TracerProviderModule.ts
@@ -1,7 +1,7 @@
 import {NativeModules, Platform} from "react-native";
 
 const LINKING_ERROR =
-  `The package 'react-native-tracer-provider' doesn't seem to be linked. Make sure: \n\n` +
+  `The package '@embrace-io/react-native-tracer-provider' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ios: "- You have run 'pod install'\n", default: ""}) +
   "- You rebuilt the app after installing the package\n" +
   "- You are not using Expo Go\n";


### PR DESCRIPTION
Auditing cases where our SDK could potentially raise unhandled exceptions, found 2 cases to address:
- Where a call to `NativeModules.EmbraceManager.<method>` is made. If `NativeModules.EmbraceManager` is undefined there's not much we can do and probably want to raise an exception as this means something wasn't setup correctly with the dependency. However we can wrap this like we were doing in `packages/react-native-tracer-provider/src/TracerProviderModule.ts` to provide a friendlier message
- Cases where we do `await EmbraceManagerModule.<method>;` without a try/catch. If the promise is rejected by the native method call in these cases then we'll throw an exception in the JS layer. I only found two spots where this is happening so wrapped those