### PR TITLE
EMBR-5733 create apps for integration testing in a separate directory

### DIFF
--- a/integration-tests/browserstack.conf.ts
+++ b/integration-tests/browserstack.conf.ts
@@ -111,7 +111,7 @@ exports.config.capabilities.forEach(function (caps) {
  */
 
 // The number of times to retry the entire specfile when it fails as a whole
-exports.config.specFileRetries = 1;
+exports.config.specFileRetries = 2;
 
 // Delay in seconds between the spec file retry attempts
 exports.config.specFileRetriesDelay = 60;
@@ -126,9 +126,9 @@ const browserStackBasicAuth = Buffer.from(
   `${process.env.BROWSERSTACK_USERNAME}:${process.env.BROWSERSTACK_ACCESS_KEY}`,
 ).toString("base64");
 
-const QUEUE_FULL_DELAY_SECONDS = 120;
-const QUEUE_FULL_RETRIES = 3;
-const QUEUE_JITTER_SECONDS = 5;
+const QUEUE_FULL_DELAY_SECONDS = 180;
+const QUEUE_FULL_RETRIES = 5;
+const QUEUE_JITTER_SECONDS = 10;
 
 /**
  * Gets executed before a worker process is spawned and can be used to initialize specific service

--- a/integration-tests/build-test-app.sh
+++ b/integration-tests/build-test-app.sh
@@ -31,21 +31,27 @@ if [[ $name == *"expo"* ]]; then
   is_expo=true
 fi
 
+# RUNNER_TEMP is set by github runners: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+# add a default in case we're not running in CI
+apps_directory="${RUNNER_TEMP:-/tmp}/rn-apps"
+mkdir -p $apps_directory
+app_path=$apps_directory/$name
 template_path="templates/$name-template"
-echo "Creating a test app from $template_path"
+
+echo "Creating a test app from $template_path at $app_path"
 if [ "$is_expo" = true ]; then
   artifact=$(ls $template_path/*.tgz)
-  echo "Running: npx create-expo $name -y --no-install --template ./$artifact"
-  npx create-expo $name -y --no-install --template ./$artifact
+  echo "Running: npx create-expo $app_path -y --no-install --template ./$artifact"
+  npx create-expo $app_path -y --no-install --template ./$artifact
 else
-  echo "Running: npx @react-native-community/cli init $name --package-name io.embrace.$name --skip-git-init --skip-install --pm yarn --template $(pwd)/$template_path"
+  echo "Running: npx @react-native-community/cli init $name --package-name io.embrace.$name --skip-git-init --skip-install --pm yarn --template $(pwd)/$template_path --directory $app_path"
 
   # Noticing that in the CI the `@react-native-community/cli` can be flaky, adding in a couple retries to get past it
   template_tries=0
   until [ "$template_tries" -ge 3 ]
   do
     npx @react-native-community/cli init $name --package-name io.embrace.$name --skip-git-init --skip-install --pm yarn \
-      --template $(pwd)/$template_path && break
+      --template $(pwd)/$template_path --directory $app_path && break
      template_tries=$((template_tries+1))
      sleep 5
   done
@@ -56,32 +62,32 @@ else
   git restore ../package.json
 fi
 
-echo "Build and install local Embrace packages in $name"
-./update-embrace-packages.sh $name
+echo "Build and install local Embrace packages for $name"
+./update-embrace-packages.sh $app_path
 
 echo "Updating the Embrace config for $name"
-./set-embrace-config.js $name embrace-configs/remote-mock-api.json --namespace=$namespace
+./set-embrace-config.js $app_path embrace-configs/remote-mock-api.json --namespace=$namespace
 
 if [ "$platform" == "android" ]; then
   echo "Building $name.apk"
-  pushd $name/android/
+  pushd $app_path/android/
   ./gradlew app:assembleRelease
   popd
 
-  mv $name/android/app/build/outputs/apk/release/app-release.apk $name.apk
+  mv $app_path/android/app/build/outputs/apk/release/app-release.apk $name.apk
 else
   ios_name="${name/-/}"
 
   echo "Installing pods for $name"
-  pushd $name/ios
+  pushd $app_path/ios
   pod install
   popd
 
-  # Browserstack will resign the .ipa before running it on their test devices so produce an unsigned one
+  # Browserstack will re-sign the .ipa before running it on their test devices so produce an unsigned one
   # here to avoid having to deal with managing our certificates
   # https://medium.com/@suyesh.kandpal28/how-to-create-an-unsigned-ipa-resign-it-with-a-new-certificate-and-upload-it-to-the-app-store-63c8dc119d20
   echo "Building $name.xcarchive"
-  xcodebuild archive -workspace $name/ios/$ios_name.xcworkspace \
+  xcodebuild archive -workspace $app_path/ios/$ios_name.xcworkspace \
   -scheme $ios_name -configuration Release \
   -sdk iphoneos -archivePath $name.xcarchive \
   CODE_SIGNING_REQUIRED=NO \

--- a/integration-tests/templates/rn71-template/package.json
+++ b/integration-tests/templates/rn71-template/package.json
@@ -16,7 +16,8 @@
     "react": "18.2.0",
     "react-native": "0.71.19",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "^3.34.0",
+    "expo-router": "~3.5.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/integration-tests/templates/rn72-template/package.json
+++ b/integration-tests/templates/rn72-template/package.json
@@ -16,7 +16,8 @@
     "react": "18.2.0",
     "react-native": "0.72.17",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "^3.34.0",
+    "expo-router": "~3.5.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/integration-tests/templates/rn73-template/package.json
+++ b/integration-tests/templates/rn73-template/package.json
@@ -16,7 +16,8 @@
     "react": "18.2.0",
     "react-native": "0.73.10",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "^3.34.0",
+    "expo-router": "~3.5.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/integration-tests/templates/rn74-template/package.json
+++ b/integration-tests/templates/rn74-template/package.json
@@ -16,7 +16,8 @@
     "react": "18.2.0",
     "react-native": "0.74.6",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "^3.34.0",
+    "expo-router": "~3.5.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/integration-tests/templates/rn75-template/package.json
+++ b/integration-tests/templates/rn75-template/package.json
@@ -16,7 +16,8 @@
     "react": "18.3.1",
     "react-native": "0.75.2",
     "react-native-safe-area-context": "^4.11.1",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "^3.34.0",
+    "expo-router": "~3.5.14"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Previously for integration tests app were being created under `embrace-react-native-sdk/integration-tests`, however this caused conflicts with the test apps' dependencies since they were looking into the `node_modules/` folders above them. Change here is to create the apps in an isolated temporary directory