### PR TITLE
run integration tests based on head branch name rather than base

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,10 +3,10 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['release/**']
 
 jobs:
   build:
+    if: startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -119,7 +119,7 @@ If the issue is related to pods try forcing a clean install with:
 
 ### Local Android development issues
 
-Try to stopping and cleaning local services (in case there are unknown issues related to the start of the app):
+Try stopping and cleaning local services (in case there are unknown issues related to the start of the app):
 
 ```bash
   cd <app>/android


### PR DESCRIPTION
Misinterpreted the `branches` filter, that is being applied to the target branch whereas we want to run integration tests whenever a branch named 'release/' is opened, using the example from: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-based-on-the-head-or-base-branch-of-a-pull-request