### PR TITLE
fix span testing screen

### DIFF
--- a/integration-tests/test-harness/src/screens/SpanTestingScreen.tsx
+++ b/integration-tests/test-harness/src/screens/SpanTestingScreen.tsx
@@ -28,9 +28,13 @@ const SpanTestingScreen = () => {
 
   const recordView = useCallback(async () => {
     try {
-      await startView("my-view");
+      const spanId = await startView("my-view");
       await new Promise(r => setTimeout(r, 2000));
-      await endView("my-view");
+      if (typeof spanId === "string") {
+        await endView(spanId);
+      } else {
+        console.log("failed to record view");
+      }
     } catch (e) {
       console.log("failed to record view");
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -301,7 +301,7 @@ export const logHandledError = (
   return createFalsePromise();
 };
 
-export const startView = (view: string): Promise<boolean> => {
+export const startView = (view: string): Promise<string | boolean> => {
   return EmbraceManagerModule.startView(view);
 };
 


### PR DESCRIPTION
Was using this method wrong, the result of startView if it's successful is an id that should then be passed to `endView`