### PR TITLE
Release v5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Individual packages are published from this monorepo, reasoning can be found in 
 | [`@embrace-io/react-native-spans`](./packages/spans)                                   | [![npm](https://img.shields.io/npm/v/@embrace-io/react-native-spans.svg?maxAge=3600)](https://www.npmjs.com/package/@embrace-io/react-native-spans)                                           |
 | [`@embrace-io/react-native-webview-tracker`](./packages/webview-tracker)               | [![npm](https://img.shields.io/npm/v/@embrace-io/react-native-webview-tracker.svg?maxAge=3600)](https://www.npmjs.com/package/@embrace-io/react-native-webview-tracker)                       |
 | [`@embrace-io/react-native-tracer-provider`](./packages/react-native-tracer-provider)  | [![npm](https://img.shields.io/npm/v/@embrace-io/react-native-tracer-provider.svg?maxAge=3600)](https://www.npmjs.com/package/@embrace-io/react-native-tracer-provider)                       |
+| [`@embrace-io/react-native-otlp`](./packages/react-native-otlp)  | [![npm](https://img.shields.io/npm/v/@embrace-io/react-native-otlp.svg?maxAge=3600)](https://www.npmjs.com/package/@embrace-io/react-native-otlp)                       |
 
 ## Support
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*"],
-  "version": "5.1.0",
+  "version": "5.2.0",
   "npmClient": "yarn"
 }

--- a/packages/action-tracker/package.json
+++ b/packages/action-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-action-tracker",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Allows tracking the dispatched actions of your state management using the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-apollo-graphql",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "This is used to track networks calls using GraphQL with the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "A React Native wrapper for the Embrace SDK",
   "dependencies": {
     "glob": "^11.0.0",

--- a/packages/react-native-navigation/package.json
+++ b/packages/react-native-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-navigation",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "This is used to track React Native screens (using React Native Navigation) with the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/react-native-otlp/README.md
+++ b/packages/react-native-otlp/README.md
@@ -176,23 +176,21 @@ Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)
 Tweak the `onCreate` method following this snippet to initialize the exporters with the minimum configuration needed. Notice that you already have all of what you need, so no extra imports are required into this file.
 
 ```kotlin
-    ...
-    // Preparing Span Exporter config with the minimum required
-    val spanExporter = OtlpHttpSpanExporter.builder()
-                                    .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces")
-                                    .addHeader("Authorization", "Basic __YOUR TOKEN__")
+// Preparing Span Exporter config with the minimum required
+val spanExporter = OtlpHttpSpanExporter.builder()
+                                .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces")
+                                .addHeader("Authorization", "Basic __YOUR TOKEN__")
 
-    // Preparing Log Exporter config with the minimum required
-    val logExporter = OtlpHttpLogRecordExporter.builder()
-                                    .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs")
-                                    .addHeader("Authorization", "Basic __YOUR TOKEN__")
+// Preparing Log Exporter config with the minimum required
+val logExporter = OtlpHttpLogRecordExporter.builder()
+                                .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs")
+                                .addHeader("Authorization", "Basic __YOUR TOKEN__")
 
-    Embrace.getInstance().addSpanExporter(spanExporter.build())
-    Embrace.getInstance().addLogRecordExporter(logExporter.build())
+Embrace.getInstance().addSpanExporter(spanExporter.build())
+Embrace.getInstance().addLogRecordExporter(logExporter.build())
 
-    // This is the line already added by the install script
-    Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)
-    ...
+// This is the line already added by the install script
+Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)
 ```
 
 

--- a/packages/react-native-otlp/README.md
+++ b/packages/react-native-otlp/README.md
@@ -117,11 +117,11 @@ export default RootLayout;
 
 ## Initializing in the Native Layer
 
-If you already have the Embrace React Native SDK initialized in the Native Side or if you are planning tu run the install scripts mentioned in our docs section you could still get benefit of the OTLP custom export feature. Remember that the the install scripts are adding the minimum code needed for initializing Embrace in the Native side but it's not integrating the configuration for exporting the telemetry data into your backend of your choice. For this you would need to tweak manually both Android/iOS sides.
+If you already have the Embrace React Native SDK initialized in the Native Side or if you are planning to run the install scripts mentioned in our docs section you could still get benefit of the OTLP custom export feature. Remember that the the install scripts are adding the minimum code needed for initializing Embrace in the Native side but are not integrating the configuration for exporting the telemetry data into your backend of your choice. For this you would need to tweak manually both the Android/iOS sides.
 
 ### iOS
 
-If you already run the install script mentioned above you would be able to find the `EmbraceInitializer.swift` file with some code.
+If you already ran the install script mentioned above you would be able to find the `EmbraceInitializer.swift` file with some initial code that you can update:
 
 ```swift
 import Foundation
@@ -167,7 +167,7 @@ let GRAFANA_LOGS_ENDPOINT = "https://otlp-gateway-prod-us-central-0.grafana.net/
 
 ## Android
 
-Similar than iOS, if you already run the install script you will see the following line already in place in your `MainApplication` file.
+Similar to iOS, if you already ran the install script you will see the following line already in place in your `MainApplication` file:
 
 ```
 Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)

--- a/packages/react-native-otlp/README.md
+++ b/packages/react-native-otlp/README.md
@@ -173,7 +173,7 @@ Similar to iOS, if you already ran the install script you will see the following
 Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)
 ```
 
-Tweak the `onCreate` method following this snippet to initialize the exporters with the minimum configuration needed. Notice that you already have all of what you need, so no extra imports are required into this file.
+Tweak the `onCreate` method using this following this snippet to initialize the exporters with the minimum configuration needed. Notice that you already have all of what you need, so no extra imports are required into this file.
 
 ```kotlin
 // Preparing Span Exporter config with the minimum required

--- a/packages/react-native-otlp/README.md
+++ b/packages/react-native-otlp/README.md
@@ -52,7 +52,7 @@ function RootLayout() {
       initEmbraceWithCustomExporters({
         logExporter: {
           endpoint:
-            "https://otlp-gateway-prod-us-east-0.grafana.net/otlp/v1/logs",
+            "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs",
           headers: [
             {
               key: "Authorization",
@@ -62,7 +62,7 @@ function RootLayout() {
         },
         traceExporter: {
           endpoint:
-            "https://otlp-gateway-prod-us-east-0.grafana.net/otlp/v1/traces",
+            "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces",
           headers: [
             {
               key: "Authorization",
@@ -114,6 +114,87 @@ function RootLayout() {
 export default RootLayout;
 
 ```
+
+## Initializing in the Native Layer
+
+If you already have the Embrace React Native SDK initialized in the Native Side or if you are planning tu run the install scripts mentioned in our docs section you could still get benefit of the OTLP custom export feature. Remember that the the install scripts are adding the minimum code needed for initializing Embrace in the Native side but it's not integrating the configuration for exporting the telemetry data into your backend of your choice. For this you would need to tweak manually both Android/iOS sides.
+
+### iOS
+
+If you already run the install script mentioned above you would be able to find the `EmbraceInitializer.swift` file with some code.
+
+```swift
+import Foundation
+import EmbraceIO
+import RNEmbraceOTLP // Do not forget to import `RNEmbraceOTLP` module which will make the proper classes available
+
+let GRAFANA_AUTH_TOKEN = "Basic __YOUR TOKEN__"
+let GRAFANA_TRACES_ENDPOINT = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces"
+let GRAFANA_LOGS_ENDPOINT = "https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs"
+
+@objcMembers class EmbraceInitializer: NSObject {
+    static func start() -> Void {
+        do {
+          // Preparing Span Exporter config with the minimum required
+          let traceExporter = OtlpHttpTraceExporter(endpoint: URL(string: GRAFANA_TRACES_ENDPOINT)!,
+            config: OtlpConfiguration(
+                headers: [("Authorization", GRAFANA_AUTH_TOKEN)]
+            )
+          )
+          
+          // Preparing Log Exporter config with the minimum required
+          let logExporter = OtlpHttpLogExporter(endpoint: URL(string: GRAFANA_LOGS_ENDPOINT)!,
+             config: OtlpConfiguration(
+                headers: [("Authorization", GRAFANA_AUTH_TOKEN)]
+             )
+          )
+          
+          try Embrace
+              .setup(
+                  options: Embrace.Options(
+                      appId: "__YOUR APP ID__",
+                      platform: .reactNative,
+                      export: OpenTelemetryExport(spanExporter: traceExporter, logExporter: logExporter) // passing the configuration into `export`
+                  )
+              )
+              .start()
+        } catch let e {
+            print("Error starting Embrace \(e.localizedDescription)")
+        }
+    }
+}
+```
+
+## Android
+
+Similar than iOS, if you already run the install script you will see the following line already in place in your `MainApplication` file.
+
+```
+Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)
+```
+
+Tweak the `onCreate` method following this snippet to initialize the exporters with the minimum configuration needed. Notice that you already have all of what you need, so no extra imports are required into this file.
+
+```kotlin
+    ...
+    // Preparing Span Exporter config with the minimum required
+    val spanExporter = OtlpHttpSpanExporter.builder()
+                                    .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/traces")
+                                    .addHeader("Authorization", "Basic __YOUR TOKEN__")
+
+    // Preparing Log Exporter config with the minimum required
+    val logExporter = OtlpHttpLogRecordExporter.builder()
+                                    .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs")
+                                    .addHeader("Authorization", "Basic __YOUR TOKEN__")
+
+    Embrace.getInstance().addSpanExporter(spanExporter.build())
+    Embrace.getInstance().addLogRecordExporter(logExporter.build())
+
+    // This is the line already added by the install script
+    Embrace.getInstance().start(this, false, Embrace.AppFramework.REACT_NATIVE)
+    ...
+```
+
 
 ## Troubleshooting
 

--- a/packages/react-native-otlp/package.json
+++ b/packages/react-native-otlp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-otlp",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "A React Native wrapper for the Embrace SDK that allows to connect to OTLP endpoints",
   "files": [
     "lib",

--- a/packages/react-native-tracer-provider/package.json
+++ b/packages/react-native-tracer-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-tracer-provider",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "A React Native for the Embrace SDK that conforms to the OpenTelemetry TracerProvider interface",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0"

--- a/packages/react-navigation/package.json
+++ b/packages/react-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-navigation",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "This is used to track React Native screens with the Embrace SDK",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/screen-orientation/package.json
+++ b/packages/screen-orientation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-orientation-change-tracker",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Allows tracking the App orientation using the Embrace SDK",
   "peerDependencies": {
     "react-native": ">=0.56.0"

--- a/packages/spans/package.json
+++ b/packages/spans/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-spans",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Embrace’s Performance Tracing solution gives you complete visibility into any customized operation you’d like to track, enabling you to identify, prioritize, and resolve any performance issue",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/webview-tracker/package.json
+++ b/packages/webview-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/react-native-webview-tracker",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Allows tracking events on WebView components using the Embrace SDK",
   "peerDependencies": {
     "react-native": ">=0.56.0"


### PR DESCRIPTION
## Goal

Embrace RN v5.2.0 to be released after Releases Freeze period (Jan, 2nd). Diff against last release (5.1.0): https://github.com/embrace-io/embrace-react-native-sdk/compare/v5.1.0...release/5.2.0

## Changelog
- `@embrace-io/react-native-otlp` going out, making the package public and releasable
- `@embrace-io/react-native` supporting `Network Span Forwarding` feature
- iOS upgrade to `v6.6.0`
- fixed Android Unit Tests that were passing without running