### PR TITLE
(fix) refactored JS unit tests for `index.ts` file

### DIFF
--- a/packages/core/src/__tests__/error.test.ts
+++ b/packages/core/src/__tests__/error.test.ts
@@ -1,3 +1,4 @@
+import {trackUnhandledError} from "../utils/error";
 import {logHandledError} from "../api/log";
 import {ComponentError, logIfComponentError} from "../api/component";
 import {LogProperties} from "../../src/interfaces";
@@ -106,5 +107,33 @@ describe("Handled JS Exceptions", () => {
     await logHandledError("not an error", undefined);
 
     expect(mockLogHandledError).not.toHaveBeenCalled();
+  });
+});
+
+describe("`trackUnhandledError()`", () => {
+  it("'Error' instance", async () => {
+    const error = new Error("`trackUnhandledError` test message");
+    trackUnhandledError("any value", error);
+
+    expect(mockLogMessageWithSeverityAndProperties).toHaveBeenCalledWith(
+      "Unhandled promise rejection: `trackUnhandledError` test message",
+      "error",
+      {},
+      error.stack,
+    );
+  });
+
+  it("not an instance of 'Error'", async () => {
+    const error = "not an Error instance";
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    trackUnhandledError("any value", error);
+
+    expect(mockLogMessageWithSeverityAndProperties).toHaveBeenCalledWith(
+      "Unhandled promise rejection: not an Error instance",
+      "error",
+      {},
+      "",
+    );
   });
 });

--- a/packages/core/src/api/component.ts
+++ b/packages/core/src/api/component.ts
@@ -1,9 +1,8 @@
+import {ErrorInfo} from "react";
+
 import {EmbraceManagerModule} from "../EmbraceManagerModule";
 
-interface ComponentError extends Error {
-  componentStack: string;
-}
-
+type ComponentError = Error & ErrorInfo;
 const isJSXError = (error: Error): error is ComponentError => {
   return "componentStack" in error;
 };

--- a/packages/core/src/hooks/useEmbrace.test.ts
+++ b/packages/core/src/hooks/useEmbrace.test.ts
@@ -61,8 +61,8 @@ describe("useEmbrace", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.isPending).toBeFalsy();
-      expect(result.current.isStarted).toBeTruthy();
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isStarted).toBe(true);
       expect(mockConsoleLog).toHaveBeenCalledWith(
         "[Embrace] native SDK was started",
       );
@@ -110,8 +110,8 @@ describe("useEmbrace", () => {
     await waitFor(() => {
       expect(mockStartNativeEmbraceSDK).toHaveBeenCalledTimes(1);
 
-      expect(result.current.isPending).toBeFalsy();
-      expect(result.current.isStarted).toBeFalsy();
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isStarted).toBe(false);
 
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "[Embrace] we could not initialize Embrace's native SDK, please check the Embrace integration docs at https://embrace.io/docs/react-native/integration/",
@@ -147,8 +147,8 @@ describe("useEmbrace", () => {
       expect(mockOltpGetStart).toHaveBeenCalledTimes(1);
       expect(mockRNEmbraceOTLPInit).toHaveBeenCalledTimes(1);
 
-      expect(result.current.isPending).toBeFalsy();
-      expect(result.current.isStarted).toBeTruthy();
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isStarted).toBe(true);
     });
   });
 
@@ -182,9 +182,9 @@ describe("useEmbrace", () => {
 
     await waitFor(() => {
       expect(mockOltpGetStart).toHaveBeenCalledTimes(1);
-      expect(result.current.isPending).toBeFalsy();
+      expect(result.current.isPending).toBe(false);
       // it should still initialize the SKD using the regular `@embrace-io/react-native` package
-      expect(result.current.isStarted).toBeTruthy();
+      expect(result.current.isStarted).toBe(true);
       expect(mockConsoleLog).toHaveBeenCalledWith(
         "[Embrace] native SDK was started",
       );
@@ -218,8 +218,8 @@ describe("useEmbrace", () => {
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "[Embrace] we could not initialize Embrace's native SDK, please check the Embrace integration docs at https://embrace.io/docs/react-native/integration/",
       );
-      expect(result.current.isPending).toBeFalsy();
-      expect(result.current.isStarted).toBeFalsy();
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isStarted).toBe(false);
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,12 +3,12 @@
 import {Platform} from "react-native";
 
 import {oltpGetStart} from "./utils/otlp";
-import {trackUnhandledErrors} from "./utils/error";
+import {setUnhandledErrors} from "./utils/error";
 import {setEmbracePackageVersion, setReactNativeVersion} from "./utils/bundle";
 import EmbraceLogger from "./utils/EmbraceLogger";
 import {SDKConfig, EmbraceLoggerLevel} from "./interfaces";
 import {handleError, handleGlobalError} from "./api/error";
-import {setJavaScriptPatch} from "./api/bundle";
+import {setJavaScriptBundlePath, setJavaScriptPatch} from "./api/bundle";
 import {EmbraceManagerModule} from "./EmbraceManagerModule";
 
 interface EmbraceInitArgs {
@@ -97,7 +97,7 @@ const initialize = async (
         await EmbraceManagerModule.getDefaultJavaScriptBundlePath();
 
       if (bundleJs) {
-        EmbraceManagerModule.setJavaScriptBundlePath(bundleJs);
+        setJavaScriptBundlePath(bundleJs);
       }
     } catch (e) {
       logger.warn(
@@ -118,7 +118,7 @@ const initialize = async (
   );
 
   // through `promise/setimmediate/rejection-tracking`
-  trackUnhandledErrors();
+  setUnhandledErrors();
 
   return Promise.resolve(true);
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,7 @@ const initialize = async (
   if (!hasNativeSDKStarted) {
     if (isIOS && !sdkConfig?.ios?.appId && !sdkConfig?.exporters) {
       logger.warn(
-        "[Embrace] 'sdkConfig.ios.appId' is required to initialize Embrace's native SDK if there is no configuration for custom exporters. Please check the Embrace integration docs at https://embrace.io/docs/react-native/integration/",
+        "'sdkConfig.ios.appId' is required to initialize Embrace's native SDK if there is no configuration for custom exporters. Please check the Embrace integration docs at https://embrace.io/docs/react-native/integration/",
       );
 
       return Promise.resolve(false);

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -1,7 +1,5 @@
 import {EmbraceManagerModule} from "../EmbraceManagerModule";
 
-const tracking = require("promise/setimmediate/rejection-tracking");
-
 const UNHANDLED_PROMISE_REJECTION_PREFIX = "Unhandled promise rejection";
 
 const trackUnhandledError = (_: unknown, error: Error) => {
@@ -20,6 +18,10 @@ const trackUnhandledError = (_: unknown, error: Error) => {
     stackTrace,
   );
 };
+
+// [Unhandled Rejections](https://github.com/then/promise/blob/master/Readme.md#unhandled-rejections)
+// [promise/setimmediate/rejection-tracking](https://github.com/then/promise/blob/master/src/rejection-tracking.js)
+const tracking = require("promise/setimmediate/rejection-tracking");
 
 const setUnhandledErrors = () => {
   tracking.enable({

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -4,27 +4,29 @@ const tracking = require("promise/setimmediate/rejection-tracking");
 
 const UNHANDLED_PROMISE_REJECTION_PREFIX = "Unhandled promise rejection";
 
-const trackUnhandledErrors = () => {
+const trackUnhandledError = (_: unknown, error: Error) => {
+  let message = `${UNHANDLED_PROMISE_REJECTION_PREFIX}: ${error}`;
+  let stackTrace = "";
+
+  if (error instanceof Error) {
+    message = `${UNHANDLED_PROMISE_REJECTION_PREFIX}: ${error.message}`;
+    stackTrace = error.stack || "";
+  }
+
+  return EmbraceManagerModule.logMessageWithSeverityAndProperties(
+    message,
+    "error",
+    {},
+    stackTrace,
+  );
+};
+
+const setUnhandledErrors = () => {
   tracking.enable({
     allRejections: true,
-    onUnhandled: (_: unknown, error: Error) => {
-      let message = `${UNHANDLED_PROMISE_REJECTION_PREFIX}: ${error}`;
-      let stackTrace = "";
-
-      if (error instanceof Error) {
-        message = `${UNHANDLED_PROMISE_REJECTION_PREFIX}: ${error.message}`;
-        stackTrace = error.stack || "";
-      }
-
-      return EmbraceManagerModule.logMessageWithSeverityAndProperties(
-        message,
-        "error",
-        {},
-        stackTrace,
-      );
-    },
+    onUnhandled: trackUnhandledError,
     onHandled: () => {},
   });
 };
 
-export {trackUnhandledErrors};
+export {setUnhandledErrors, trackUnhandledError};


### PR DESCRIPTION
## Goal

- refactored tests that cover the `initialize` main method for RN sdk
- console log/warn messages displayed across the workflow silenced at least for this file for now and adding checks around those (those were making the workflow noisy and difficult to inspect in case real failures) .