### PR TITLE
EMBR-6294 fix calls to logMessageWithSeverityAndProperties

### DIFF
--- a/packages/core/src/__tests__/error.test.ts
+++ b/packages/core/src/__tests__/error.test.ts
@@ -1,7 +1,7 @@
 import {trackUnhandledError} from "../utils/error";
 import {logHandledError} from "../api/log";
 import {ComponentError, logIfComponentError} from "../api/component";
-import {LogProperties} from "../../src/interfaces";
+import {LogProperties, LogSeverity} from "../../src/interfaces";
 
 const mockLogHandledError = jest.fn();
 const mockLogMessageWithSeverityAndProperties = jest.fn();
@@ -15,15 +15,17 @@ jest.mock("../EmbraceManagerModule", () => ({
     ) => mockLogHandledError(message, stackTrace, properties),
     logMessageWithSeverityAndProperties: (
       message: string,
-      errorType: string,
+      severity: LogSeverity,
       properties: LogProperties,
-      componentStack: string,
+      stacktrace: string,
+      includeStacktrace: boolean,
     ) => {
       mockLogMessageWithSeverityAndProperties(
         message,
-        errorType,
+        severity,
         properties,
-        componentStack,
+        stacktrace,
+        includeStacktrace,
       );
       return Promise.resolve(true);
     },
@@ -71,6 +73,7 @@ describe("Component Error", () => {
         "error",
         {},
         "in SomeScreen/n in SomeOtherScreen",
+        true,
       );
     });
   });
@@ -120,6 +123,7 @@ describe("`trackUnhandledError()`", () => {
       "error",
       {},
       error.stack,
+      true,
     );
   });
 
@@ -134,6 +138,7 @@ describe("`trackUnhandledError()`", () => {
       "error",
       {},
       "",
+      false,
     );
   });
 });

--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -38,12 +38,14 @@ jest.mock("../EmbraceManagerModule", () => ({
       severity: string,
       properties: object,
       stacktrace: string,
+      includeStacktrace: boolean,
     ) =>
       mockLogMessageWithSeverityAndProperties(
         message,
         severity,
         properties,
         stacktrace,
+        includeStacktrace,
       ),
     logUnhandledJSException: (
       name: string,
@@ -179,6 +181,7 @@ describe("SDK initialization", () => {
           "error",
           {},
           "in SomeScreen\n in SomeOtherScreen",
+          true,
         );
         expect(mockPreviousHandler).toHaveBeenCalledWith(componentError, false);
       });

--- a/packages/core/src/api/component.ts
+++ b/packages/core/src/api/component.ts
@@ -45,6 +45,7 @@ const logIfComponentError = (error: Error): Promise<boolean> => {
     "error",
     {},
     componentStack,
+    true,
   );
 };
 

--- a/packages/core/src/utils/error.ts
+++ b/packages/core/src/utils/error.ts
@@ -16,6 +16,7 @@ const trackUnhandledError = (_: unknown, error: Error) => {
     "error",
     {},
     stackTrace,
+    !!stackTrace,
   );
 };
 


### PR DESCRIPTION
Component render errors + unhandled promise rejections were missing the last parameter when calling `logMessageWithSeverityAndProperties`