### PR TITLE
EMBR-6294 make sure span native IDs don't collide with multiple tracer providers

### DIFF
--- a/packages/react-native-tracer-provider/src/EmbraceNativeSpan.ts
+++ b/packages/react-native-tracer-provider/src/EmbraceNativeSpan.ts
@@ -29,6 +29,12 @@ import {TracerProviderModule} from "./TracerProviderModule";
  *
  * The JS side of this implementation is modelled after [opentelemetry-sdk-trace-base](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base)
  */
+
+// Need an ID that spans from JS can use to communicate with their stored instances on the native side. A uuid would
+// work but did not want to introduce extra work or another dependency here. Instead, it should be enough to keep a
+// global count of the spans created by any tracer or tracer provider and use a given span's createdIndex as their ID
+let spansCreated = 0;
+
 class EmbraceNativeSpan implements Span {
   private readonly tracerName: string;
   private readonly tracerVersion: string;
@@ -43,17 +49,17 @@ class EmbraceNativeSpan implements Span {
     tracerName: string,
     tracerVersion: string,
     tracerSchemaUrl: string,
-    createdIndex: number,
     spanContextSyncBehaviour: SpanContextSyncBehaviour,
   ) {
     this.tracerName = tracerName;
     this.tracerVersion = tracerVersion;
     this.tracerSchemaUrl = tracerSchemaUrl;
-    this.createdIndex = createdIndex;
     this.spanContextSyncBehaviour = spanContextSyncBehaviour;
+    this.createdIndex = spansCreated++;
   }
 
   public nativeID(): string {
+    // Only `this.createdIndex` is strictly needed for uniqueness, keeping the other values for debugging purposes
     return `${this.tracerName}_${this.tracerVersion}_${this.tracerSchemaUrl}_${this.createdIndex}`;
   }
 

--- a/packages/react-native-tracer-provider/src/EmbraceNativeTracer.ts
+++ b/packages/react-native-tracer-provider/src/EmbraceNativeTracer.ts
@@ -33,7 +33,6 @@ class EmbraceNativeTracer implements Tracer {
   private readonly name: string;
   private readonly version: string;
   private readonly schemaUrl: string;
-  private spansCreated: number;
   private readonly contextManager: ContextManager;
   private readonly spanContextSyncBehaviour: SpanContextSyncBehaviour;
   constructor(
@@ -46,7 +45,6 @@ class EmbraceNativeTracer implements Tracer {
     this.name = name;
     this.version = version;
     this.schemaUrl = schemaUrl;
-    this.spansCreated = 0;
     this.contextManager = contextManager;
     this.spanContextSyncBehaviour = spanContextSyncBehaviour;
   }
@@ -62,12 +60,10 @@ class EmbraceNativeTracer implements Tracer {
     ) as EmbraceNativeSpan;
     const parentNativeID = (!root && parentSpan && parentSpan.nativeID()) || "";
 
-    this.spansCreated += 1;
     const nativeSpan = new EmbraceNativeSpan(
       this.name,
       this.version,
       this.schemaUrl,
-      this.spansCreated,
       this.spanContextSyncBehaviour,
     );
 


### PR DESCRIPTION
Whenever a span is created it gets an ID to communicate with its native instance, for a single tracer these wouldn't have collided since the ID included a created at index provided by the tracer, however with multiple tracers + tracer providers this wouldn't be unique anymore.

Switched the created at index to be global for all spans which I think should handle the scenario. Generating a uuid is also possible though I was hoping to avoid introducing a dependency just for that