### PR TITLE
EMBR-5980 fix sourcemap upload

### DIFF
--- a/packages/core/scripts/__tests__/__mocks__/ios/testMock.xcodeproj/project.pbxproj
+++ b/packages/core/scripts/__tests__/__mocks__/ios/testMock.xcodeproj/project.pbxproj
@@ -286,7 +286,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nexport SOURCEMAP_FILE=\"$CONFIGURATION_BUILD_DIR/main.jsbundle.map\";\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nmkdir -p \"$CONFIGURATION_BUILD_DIR/embrace-assets\"\nexport SOURCEMAP_FILE=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\";\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/core/scripts/setup/ios.ts
+++ b/packages/core/scripts/setup/ios.ts
@@ -7,6 +7,7 @@ import {
   podfilePatchable,
   xcodePatchable,
   findNameWithCaseSensitiveFromPath,
+  makeSourcemapDirectory,
 } from "../util/ios";
 import EmbraceLogger from "../../src/utils/EmbraceLogger";
 
@@ -101,7 +102,7 @@ export const patchXcodeBundlePhase = {
         project.modifyPhase(
           bundlePhaseKey,
           /^.*?\/(packager|scripts)\/react-native-xcode\.sh\s*/m,
-          `${exportSourcemapRNVariable}\n`,
+          `${makeSourcemapDirectory}\n${exportSourcemapRNVariable}\n`,
         );
         return project.patch();
       }),
@@ -129,7 +130,7 @@ export const addUploadBuildPhase = {
             null,
             {
               shellPath: "/bin/sh",
-              shellScript: `REACT_NATIVE_MAP_PATH="$CONFIGURATION_BUILD_DIR/main.jsbundle.map" EMBRACE_ID=${id} EMBRACE_TOKEN=${token} ${embRunScript}`,
+              shellScript: `REACT_NATIVE_MAP_PATH="$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map" EMBRACE_ID=${id} EMBRACE_TOKEN=${token} ${embRunScript}`,
             },
           );
           return project.patch();

--- a/packages/core/scripts/setup/uninstall.ts
+++ b/packages/core/scripts/setup/uninstall.ts
@@ -6,6 +6,7 @@ import {
   exportSourcemapRNVariable,
   findNameWithCaseSensitiveFromPath,
   getPodFile,
+  makeSourcemapDirectory,
   xcodePatchable,
 } from "../util/ios";
 import {FileUpdatable} from "../util/file";
@@ -226,7 +227,7 @@ export const removeEmbraceFromXcode = () => {
         project.findAndRemovePhase("Upload Debug Symbols to Embrace");
         project.modifyPhase(
           bundlePhaseKey,
-          `${exportSourcemapRNVariable}\n`,
+          `${makeSourcemapDirectory}\n${exportSourcemapRNVariable}\n`,
           "",
         );
         project.findAndRemovePhase("/EmbraceIO/run.sh");

--- a/packages/core/scripts/util/ios.ts
+++ b/packages/core/scripts/util/ios.ts
@@ -15,8 +15,10 @@ export const embraceNativePod = `pod 'EmbraceIO'`;
 
 export const bundlePhaseRE = /react-native-xcode\.sh/;
 
+export const makeSourcemapDirectory =
+  'mkdir -p "$CONFIGURATION_BUILD_DIR/embrace-assets"';
 export const exportSourcemapRNVariable =
-  'export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map";';
+  'export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map";';
 
 export const EMBRACE_IMPORT_OBJECTIVEC = ({
   bridgingHeader,


### PR DESCRIPTION
Previously we triggered source map generation on iOS by updating the react native build phase with:
```
export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
```

when this variable is set the react native xcode script emits a map file:
https://github.com/facebook/react-native/blob/17c34295a18c707ea28dc7f6f8566bdb57472b83/packages/react-native/scripts/react-native-xcode.sh#L127

however the problem was with our naming, "$CONFIGURATION_BUILD_DIR/main.jsbundle.map" is exactly the same name that gets used for `PACKAGER_SOURCEMAP_FILE`: https://github.com/facebook/react-native/blob/17c34295a18c707ea28dc7f6f8566bdb57472b83/packages/react-native/scripts/react-native-xcode.sh#L133 and the last thing the script does is `rm $PACKAGER_SOURCEMAP_FILE` which deletes the source map file we just generated: https://github.com/facebook/react-native/blob/17c34295a18c707ea28dc7f6f8566bdb57472b83/packages/react-native/scripts/react-native-xcode.sh#L184

even with this problem sourcemap upload continued to work for some apps because the upload script we package with the pod attempts to create the sourcemap if it isn't able to find it: https://github.com/embrace-io/go/blob/master/tool/ios-upload/run.sh#L114. This assumed the entry file was "index.js" which worked for bare RN apps but failed for Expo apps that had a different entry point

just changing the filename isn't enough because `basename "$SOURCEMAP_FILE"` is used to get `PACKAGER_SOURCEMAP_FILE`'s name so it'll end up with the same problem. Solution here is to create a new directory in the build folder and place our sourcemap in there which protects it from getting removed

also updating manual instructions in docs: https://github.com/embrace-io/embrace-docs/pull/182