### PR TITLE
EMBR-6828 add navigation attributes when span starts

### DIFF
--- a/packages/react-native-navigation/src/instrumentation/utils/spanFactory.ts
+++ b/packages/react-native-navigation/src/instrumentation/utils/spanFactory.ts
@@ -25,19 +25,16 @@ const spanStart = (
     return;
   }
 
-  // Starting the span
-  span.current = tracer.current.startSpan(currentRouteName);
-
-  span.current.setAttributes({
+  const attributes = {
     // it should create the first span knowing there is not a previous view
     [ATTRIBUTES.initialView]: !!isLaunch,
     // it should set the view name in case it's useful to have this as an attr
     [ATTRIBUTES.viewName]: currentRouteName,
-  });
+    ...customAttributes,
+  };
 
-  if (customAttributes) {
-    span.current.setAttributes(customAttributes);
-  }
+  // Starting the span
+  span.current = tracer.current.startSpan(currentRouteName, {attributes});
 };
 
 const spanEnd = (


### PR DESCRIPTION
If a crash happens right after this span is created it's possible that its attributes will not have been persisted to disk by the native SDK, instead since we know the attributes ahead of time include them when starting the span