### PR TITLE
update iOS SDK dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "typescript": "^5.6.3"
   },
   "embrace": {
-    "iosVersion": "6.8.1",
+    "iosVersion": "6.8.5",
     "androidVersion": "7.2.0"
   }
 }

--- a/packages/core/test-project/ios/Podfile.lock
+++ b/packages/core/test-project/ios/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EmbraceIO (6.8.1):
-    - EmbraceIO/EmbraceIO (= 6.8.1)
-  - EmbraceIO/EmbraceCaptureService (6.8.1):
+  - EmbraceIO (6.8.5):
+    - EmbraceIO/EmbraceIO (= 6.8.5)
+  - EmbraceIO/EmbraceCaptureService (6.8.5):
     - EmbraceIO/EmbraceOTelInternal
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceCommonInternal (6.8.1)
-  - EmbraceIO/EmbraceConfigInternal (6.8.1):
+  - EmbraceIO/EmbraceCommonInternal (6.8.5)
+  - EmbraceIO/EmbraceConfigInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceConfiguration
-  - EmbraceIO/EmbraceConfiguration (6.8.1)
-  - EmbraceIO/EmbraceCore (6.8.1):
+  - EmbraceIO/EmbraceConfiguration (6.8.5)
+  - EmbraceIO/EmbraceCore (6.8.5):
     - EmbraceIO/EmbraceCaptureService
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceConfigInternal
@@ -21,46 +21,46 @@ PODS:
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/EmbraceStorageInternal
     - EmbraceIO/EmbraceUploadInternal
-  - EmbraceIO/EmbraceCoreDataInternal (6.8.1):
+  - EmbraceIO/EmbraceCoreDataInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
-  - EmbraceIO/EmbraceCrash (6.8.1):
+  - EmbraceIO/EmbraceCrash (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/KSCrash
-  - EmbraceIO/EmbraceIO (6.8.1):
+  - EmbraceIO/EmbraceIO (6.8.5):
     - EmbraceIO/EmbraceCaptureService
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceCore
     - EmbraceIO/EmbraceCrash
     - EmbraceIO/EmbraceSemantics
-  - EmbraceIO/EmbraceObjCUtilsInternal (6.8.1)
-  - EmbraceIO/EmbraceOTelInternal (6.8.1):
+  - EmbraceIO/EmbraceObjCUtilsInternal (6.8.5)
+  - EmbraceIO/EmbraceOTelInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceSemantics (6.8.1):
+  - EmbraceIO/EmbraceSemantics (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceStorageInternal (6.8.1):
+  - EmbraceIO/EmbraceStorageInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/GRDB
-  - EmbraceIO/EmbraceUploadInternal (6.8.1):
+  - EmbraceIO/EmbraceUploadInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceCoreDataInternal
     - EmbraceIO/EmbraceOTelInternal
     - EmbraceIO/GRDB
-  - EmbraceIO/GRDB (6.8.1)
-  - EmbraceIO/KSCrash (6.8.1):
+  - EmbraceIO/GRDB (6.8.5)
+  - EmbraceIO/KSCrash (6.8.5):
     - EmbraceIO/KSCrashCore
     - EmbraceIO/KSCrashRecording
     - EmbraceIO/KSCrashRecordingCore
-  - EmbraceIO/KSCrashCore (6.8.1)
-  - EmbraceIO/KSCrashRecording (6.8.1):
+  - EmbraceIO/KSCrashCore (6.8.5)
+  - EmbraceIO/KSCrashRecording (6.8.5):
     - EmbraceIO/KSCrashRecordingCore
-  - EmbraceIO/KSCrashRecordingCore (6.8.1):
+  - EmbraceIO/KSCrashRecordingCore (6.8.5):
     - EmbraceIO/KSCrashCore
-  - EmbraceIO/OpenTelemetryApi (6.8.1)
-  - EmbraceIO/OpenTelemetrySdk (6.8.1):
+  - EmbraceIO/OpenTelemetryApi (6.8.5)
+  - EmbraceIO/OpenTelemetrySdk (6.8.5):
     - EmbraceIO/OpenTelemetryApi
   - FBLazyVector (0.75.4)
   - fmt (9.1.0)
@@ -1564,7 +1564,7 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
-  - EmbraceIO (= 6.8.1)
+  - EmbraceIO (= 6.8.5)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
@@ -1763,7 +1763,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  EmbraceIO: 2171ee7e8870a8a2697c3475c333789ebabd1e14
+  EmbraceIO: 05dc3d5ea307acfce9d64eccfe475fb0c3118c3d
   FBLazyVector: 430e10366de01d1e3d57374500b1b150fe482e6d
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb

--- a/packages/react-native-navigation/package.json
+++ b/packages/react-native-navigation/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.6.3"
   },
   "embrace": {
-    "iosVersion": "6.8.1",
+    "iosVersion": "6.8.5",
     "androidVersion": "7.2.0"
   },
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",

--- a/packages/react-native-otlp/package.json
+++ b/packages/react-native-otlp/package.json
@@ -32,7 +32,7 @@
     "typescript": "^5.6.3"
   },
   "embrace": {
-    "iosVersion": "6.8.1",
+    "iosVersion": "6.8.5",
     "androidVersion": "7.2.0"
   },
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",

--- a/packages/react-native-otlp/test-project/ios/Podfile.lock
+++ b/packages/react-native-otlp/test-project/ios/Podfile.lock
@@ -2,17 +2,17 @@ PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - EmbraceInternalSwiftLog (1.4.4-internal)
-  - EmbraceIO (6.8.1):
-    - EmbraceIO/EmbraceIO (= 6.8.1)
-  - EmbraceIO/EmbraceCaptureService (6.8.1):
+  - EmbraceIO (6.8.5):
+    - EmbraceIO/EmbraceIO (= 6.8.5)
+  - EmbraceIO/EmbraceCaptureService (6.8.5):
     - EmbraceIO/EmbraceOTelInternal
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceCommonInternal (6.8.1)
-  - EmbraceIO/EmbraceConfigInternal (6.8.1):
+  - EmbraceIO/EmbraceCommonInternal (6.8.5)
+  - EmbraceIO/EmbraceConfigInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceConfiguration
-  - EmbraceIO/EmbraceConfiguration (6.8.1)
-  - EmbraceIO/EmbraceCore (6.8.1):
+  - EmbraceIO/EmbraceConfiguration (6.8.5)
+  - EmbraceIO/EmbraceCore (6.8.5):
     - EmbraceIO/EmbraceCaptureService
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceConfigInternal
@@ -22,46 +22,46 @@ PODS:
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/EmbraceStorageInternal
     - EmbraceIO/EmbraceUploadInternal
-  - EmbraceIO/EmbraceCoreDataInternal (6.8.1):
+  - EmbraceIO/EmbraceCoreDataInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
-  - EmbraceIO/EmbraceCrash (6.8.1):
+  - EmbraceIO/EmbraceCrash (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/KSCrash
-  - EmbraceIO/EmbraceIO (6.8.1):
+  - EmbraceIO/EmbraceIO (6.8.5):
     - EmbraceIO/EmbraceCaptureService
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceCore
     - EmbraceIO/EmbraceCrash
     - EmbraceIO/EmbraceSemantics
-  - EmbraceIO/EmbraceObjCUtilsInternal (6.8.1)
-  - EmbraceIO/EmbraceOTelInternal (6.8.1):
+  - EmbraceIO/EmbraceObjCUtilsInternal (6.8.5)
+  - EmbraceIO/EmbraceOTelInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceSemantics (6.8.1):
+  - EmbraceIO/EmbraceSemantics (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceStorageInternal (6.8.1):
+  - EmbraceIO/EmbraceStorageInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/GRDB
-  - EmbraceIO/EmbraceUploadInternal (6.8.1):
+  - EmbraceIO/EmbraceUploadInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceCoreDataInternal
     - EmbraceIO/EmbraceOTelInternal
     - EmbraceIO/GRDB
-  - EmbraceIO/GRDB (6.8.1)
-  - EmbraceIO/KSCrash (6.8.1):
+  - EmbraceIO/GRDB (6.8.5)
+  - EmbraceIO/KSCrash (6.8.5):
     - EmbraceIO/KSCrashCore
     - EmbraceIO/KSCrashRecording
     - EmbraceIO/KSCrashRecordingCore
-  - EmbraceIO/KSCrashCore (6.8.1)
-  - EmbraceIO/KSCrashRecording (6.8.1):
+  - EmbraceIO/KSCrashCore (6.8.5)
+  - EmbraceIO/KSCrashRecording (6.8.5):
     - EmbraceIO/KSCrashRecordingCore
-  - EmbraceIO/KSCrashRecordingCore (6.8.1):
+  - EmbraceIO/KSCrashRecordingCore (6.8.5):
     - EmbraceIO/KSCrashCore
-  - EmbraceIO/OpenTelemetryApi (6.8.1)
-  - EmbraceIO/OpenTelemetrySdk (6.8.1):
+  - EmbraceIO/OpenTelemetryApi (6.8.5)
+  - EmbraceIO/OpenTelemetrySdk (6.8.5):
     - EmbraceIO/OpenTelemetryApi
   - FBLazyVector (0.75.4)
   - fmt (9.1.0)
@@ -1567,7 +1567,7 @@ DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EmbraceInternalSwiftLog (= 1.4.4-internal)
-  - EmbraceIO (= 6.8.1)
+  - EmbraceIO (= 6.8.5)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
@@ -1770,7 +1770,7 @@ SPEC CHECKSUMS:
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   EmbraceInternalSwiftLog: a7b20002f2ca34400678012c3c3e8f7d51da5c79
-  EmbraceIO: 2171ee7e8870a8a2697c3475c333789ebabd1e14
+  EmbraceIO: 05dc3d5ea307acfce9d64eccfe475fb0c3118c3d
   FBLazyVector: 430e10366de01d1e3d57374500b1b150fe482e6d
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb

--- a/packages/react-native-redux/package.json
+++ b/packages/react-native-redux/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.6.3"
   },
   "embrace": {
-    "iosVersion": "6.8.1",
+    "iosVersion": "6.8.5",
     "androidVersion": "7.2.0"
   }
 }

--- a/packages/react-native-tracer-provider/package.json
+++ b/packages/react-native-tracer-provider/package.json
@@ -59,7 +59,7 @@
     "typescript": "^5.6.3"
   },
   "embrace": {
-    "iosVersion": "6.8.1",
+    "iosVersion": "6.8.5",
     "androidVersion": "7.2.0"
   }
 }

--- a/packages/react-native-tracer-provider/test-project/ios/Podfile.lock
+++ b/packages/react-native-tracer-provider/test-project/ios/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EmbraceIO (6.8.1):
-    - EmbraceIO/EmbraceIO (= 6.8.1)
-  - EmbraceIO/EmbraceCaptureService (6.8.1):
+  - EmbraceIO (6.8.5):
+    - EmbraceIO/EmbraceIO (= 6.8.5)
+  - EmbraceIO/EmbraceCaptureService (6.8.5):
     - EmbraceIO/EmbraceOTelInternal
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceCommonInternal (6.8.1)
-  - EmbraceIO/EmbraceConfigInternal (6.8.1):
+  - EmbraceIO/EmbraceCommonInternal (6.8.5)
+  - EmbraceIO/EmbraceConfigInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceConfiguration
-  - EmbraceIO/EmbraceConfiguration (6.8.1)
-  - EmbraceIO/EmbraceCore (6.8.1):
+  - EmbraceIO/EmbraceConfiguration (6.8.5)
+  - EmbraceIO/EmbraceCore (6.8.5):
     - EmbraceIO/EmbraceCaptureService
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceConfigInternal
@@ -21,46 +21,46 @@ PODS:
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/EmbraceStorageInternal
     - EmbraceIO/EmbraceUploadInternal
-  - EmbraceIO/EmbraceCoreDataInternal (6.8.1):
+  - EmbraceIO/EmbraceCoreDataInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
-  - EmbraceIO/EmbraceCrash (6.8.1):
+  - EmbraceIO/EmbraceCrash (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/KSCrash
-  - EmbraceIO/EmbraceIO (6.8.1):
+  - EmbraceIO/EmbraceIO (6.8.5):
     - EmbraceIO/EmbraceCaptureService
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceCore
     - EmbraceIO/EmbraceCrash
     - EmbraceIO/EmbraceSemantics
-  - EmbraceIO/EmbraceObjCUtilsInternal (6.8.1)
-  - EmbraceIO/EmbraceOTelInternal (6.8.1):
+  - EmbraceIO/EmbraceObjCUtilsInternal (6.8.5)
+  - EmbraceIO/EmbraceOTelInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceSemantics (6.8.1):
+  - EmbraceIO/EmbraceSemantics (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/OpenTelemetrySdk
-  - EmbraceIO/EmbraceStorageInternal (6.8.1):
+  - EmbraceIO/EmbraceStorageInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceSemantics
     - EmbraceIO/GRDB
-  - EmbraceIO/EmbraceUploadInternal (6.8.1):
+  - EmbraceIO/EmbraceUploadInternal (6.8.5):
     - EmbraceIO/EmbraceCommonInternal
     - EmbraceIO/EmbraceCoreDataInternal
     - EmbraceIO/EmbraceOTelInternal
     - EmbraceIO/GRDB
-  - EmbraceIO/GRDB (6.8.1)
-  - EmbraceIO/KSCrash (6.8.1):
+  - EmbraceIO/GRDB (6.8.5)
+  - EmbraceIO/KSCrash (6.8.5):
     - EmbraceIO/KSCrashCore
     - EmbraceIO/KSCrashRecording
     - EmbraceIO/KSCrashRecordingCore
-  - EmbraceIO/KSCrashCore (6.8.1)
-  - EmbraceIO/KSCrashRecording (6.8.1):
+  - EmbraceIO/KSCrashCore (6.8.5)
+  - EmbraceIO/KSCrashRecording (6.8.5):
     - EmbraceIO/KSCrashRecordingCore
-  - EmbraceIO/KSCrashRecordingCore (6.8.1):
+  - EmbraceIO/KSCrashRecordingCore (6.8.5):
     - EmbraceIO/KSCrashCore
-  - EmbraceIO/OpenTelemetryApi (6.8.1)
-  - EmbraceIO/OpenTelemetrySdk (6.8.1):
+  - EmbraceIO/OpenTelemetryApi (6.8.5)
+  - EmbraceIO/OpenTelemetrySdk (6.8.5):
     - EmbraceIO/OpenTelemetryApi
   - FBLazyVector (0.75.4)
   - fmt (9.1.0)
@@ -1564,7 +1564,7 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
-  - EmbraceIO (= 6.8.1)
+  - EmbraceIO (= 6.8.5)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
@@ -1763,7 +1763,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  EmbraceIO: 2171ee7e8870a8a2697c3475c333789ebabd1e14
+  EmbraceIO: 05dc3d5ea307acfce9d64eccfe475fb0c3118c3d
   FBLazyVector: 430e10366de01d1e3d57374500b1b150fe482e6d
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -127,7 +127,7 @@ function enforceEmbraceMetadata({Yarn}) {
     }
 
     workspace.set("embrace", {
-      iosVersion: "6.8.1",
+      iosVersion: "6.8.5",
       androidVersion: "7.2.0",
     });
   }


### PR DESCRIPTION
## Goal

Take advantage of fixes we are missing from the latest iOS SDK, specifically for network capture (see https://github.com/embrace-io/embrace-react-native-sdk/issues/473)