### PR TITLE
[EMBR-4243] Add TurboModule (New Architecture) support to all native packages

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -60,11 +60,26 @@ android {
     }
   }
 
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += 'src/newarch/java'
+      } else {
+        java.srcDirs += 'src/oldarch/java'
+      }
+    }
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+  }
+
+  buildFeatures {
+    buildConfig true
   }
 
   buildTypes {

--- a/packages/core/android/src/main/java/io/embrace/rnembracecore/EmbraceManagerModule.java
+++ b/packages/core/android/src/main/java/io/embrace/rnembracecore/EmbraceManagerModule.java
@@ -3,7 +3,6 @@ package io.embrace.rnembracecore;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 
@@ -20,7 +19,8 @@ import io.embrace.android.embracesdk.Severity;
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest;
 import io.embrace.android.embracesdk.network.http.HttpMethod;
 
-public class EmbraceManagerModule extends ReactContextBaseJavaModule {
+public class EmbraceManagerModule extends EmbraceManagerSpec {
+    public static final String NAME = "EmbraceManager";
     private final ReactApplicationContext context;
 
     public EmbraceManagerModule(ReactApplicationContext reactContext) {
@@ -31,7 +31,7 @@ public class EmbraceManagerModule extends ReactContextBaseJavaModule {
     @Nonnull
     @Override
     public String getName() {
-        return "EmbraceManager";
+        return NAME;
     }
 
     @ReactMethod
@@ -313,6 +313,11 @@ public class EmbraceManagerModule extends ReactContextBaseJavaModule {
         } catch(Exception e) {
             promise.reject("GET_CURRENT_SESSION_ID_ERROR", "Error getting current session ID", e);
         }
+    }
+
+    @ReactMethod
+    public void getDefaultJavaScriptBundlePath(Promise promise) {
+        promise.resolve("");
     }
 
     @ReactMethod

--- a/packages/core/android/src/main/java/io/embrace/rnembracecore/EmbraceManagerPackage.java
+++ b/packages/core/android/src/main/java/io/embrace/rnembracecore/EmbraceManagerPackage.java
@@ -1,28 +1,41 @@
 
 package io.embrace.rnembracecore;
 
-import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.module.model.ReactModuleInfo;
+import com.facebook.react.module.model.ReactModuleInfoProvider;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-public class EmbraceManagerPackage implements ReactPackage {
-		@Override
-		public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-			return Arrays.<NativeModule>asList(new EmbraceManagerModule(reactContext));
-		}
+public class EmbraceManagerPackage extends TurboReactPackage {
+    @Override
+    public NativeModule getModule(String name, ReactApplicationContext reactContext) {
+        if (name.equals(EmbraceManagerModule.NAME)) {
+            return new EmbraceManagerModule(reactContext);
+        }
+        return null;
+    }
 
-		public List<Class<? extends JavaScriptModule>> createJSModules() {
-			return Collections.emptyList();
-		}
-
-		@Override
-		public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-			return Collections.emptyList();
-		}
+    @Override
+    public ReactModuleInfoProvider getReactModuleInfoProvider() {
+        return () -> {
+            final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
+            boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+            moduleInfos.put(
+                EmbraceManagerModule.NAME,
+                new ReactModuleInfo(
+                    EmbraceManagerModule.NAME,
+                    EmbraceManagerModule.NAME,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    false, // isCxxModule
+                    isTurboModule // isTurboModule
+                )
+            );
+            return moduleInfos;
+        };
+    }
 }

--- a/packages/core/android/src/newarch/java/io/embrace/rnembracecore/EmbraceManagerSpec.java
+++ b/packages/core/android/src/newarch/java/io/embrace/rnembracecore/EmbraceManagerSpec.java
@@ -1,0 +1,9 @@
+package io.embrace.rnembracecore;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+
+abstract class EmbraceManagerSpec extends NativeEmbraceManagerSpec {
+    EmbraceManagerSpec(ReactApplicationContext context) {
+        super(context);
+    }
+}

--- a/packages/core/android/src/oldarch/java/io/embrace/rnembracecore/EmbraceManagerSpec.java
+++ b/packages/core/android/src/oldarch/java/io/embrace/rnembracecore/EmbraceManagerSpec.java
@@ -1,0 +1,10 @@
+package io.embrace.rnembracecore;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+
+abstract class EmbraceManagerSpec extends ReactContextBaseJavaModule {
+    EmbraceManagerSpec(ReactApplicationContext context) {
+        super(context);
+    }
+}

--- a/packages/core/ios/EmbraceManager.mm
+++ b/packages/core/ios/EmbraceManager.mm
@@ -1,5 +1,9 @@
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNEmbraceCoreSpec/RNEmbraceCoreSpec.h>
+#endif
+
 @interface RCT_EXTERN_MODULE(EmbraceManager, NSObject)
 
 RCT_EXTERN_METHOD(setJavaScriptBundlePath:(NSString *)path
@@ -132,3 +136,13 @@ RCT_EXTERN_METHOD(logUnhandledJSException:(NSString *)name
 }
 
 @end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+@implementation EmbraceManager (TurboModule)
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeEmbraceManagerSpecJSI>(params);
+}
+@end
+#endif

--- a/packages/core/ios/EmbraceManager.swift
+++ b/packages/core/ios/EmbraceManager.swift
@@ -4,6 +4,10 @@ import OSLog
 import EmbraceIO
 import OpenTelemetryApi
 
+#if RCT_NEW_ARCH_ENABLED
+import RNEmbraceCoreSpec
+#endif
+
 private let JAVASCRIPT_PATCH_NUMBER_RESOURCE_KEY = "javascript_patch_number"
 private let HOSTED_PLATFORM_VERSION_RESOURCE_KEY = "hosted_platform_version"
 private let HOSTED_SDK_VERSION_RESOURCE_KEY = "hosted_sdk_version"
@@ -557,3 +561,7 @@ class EmbraceManager: NSObject {
         span.setAttribute(key: "emb.w3c_traceparent", value: W3C.traceparent(from: span.context))
     }
 }
+
+#if RCT_NEW_ARCH_ENABLED
+extension EmbraceManager: NativeEmbraceManagerSpec {}
+#endif

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,8 @@
     "android/gradle.properties",
     "android/dependencies.gradle",
     "ios",
-    "RNEmbraceCore.podspec"
+    "RNEmbraceCore.podspec",
+    "src/NativeEmbraceManager.ts"
   ],
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {
@@ -71,5 +72,13 @@
   "embrace": {
     "iosVersion": "6.16.2",
     "androidVersion": "7.9.2"
+  },
+  "codegenConfig": {
+    "name": "RNEmbraceCoreSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "io.embrace.rnembracecore"
+    }
   }
 }

--- a/packages/core/scripts/__tests__/__mocks__/android/buildWithSwazzler.gradle
+++ b/packages/core/scripts/__tests__/__mocks__/android/buildWithSwazzler.gradle
@@ -26,6 +26,7 @@ buildscript {
         classpath "io.embrace:embrace-swazzler:${findProject(':embrace-io_react-native').properties['emb_android_sdk']}"
         
         
+        
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/core/src/EmbraceManagerModule.ts
+++ b/packages/core/src/EmbraceManagerModule.ts
@@ -6,8 +6,15 @@ const LINKING_ERROR =
   "- You rebuilt the app after installing the package\n" +
   "- You are not using Expo Go\n";
 
-export const EmbraceManagerModule = NativeModules.EmbraceManager
-  ? NativeModules.EmbraceManager
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- standard React Native TurboModule detection
+const isTurboModuleEnabled = (global as any).__turboModuleProxy != null;
+
+const NativeModule = isTurboModuleEnabled
+  ? require("./NativeEmbraceManager").default
+  : NativeModules.EmbraceManager;
+
+export const EmbraceManagerModule = NativeModule
+  ? NativeModule
   : new Proxy(
       {},
       {

--- a/packages/core/src/NativeEmbraceManager.ts
+++ b/packages/core/src/NativeEmbraceManager.ts
@@ -1,0 +1,70 @@
+import type {TurboModule} from "react-native";
+import {TurboModuleRegistry} from "react-native";
+
+/* eslint-disable @typescript-eslint/ban-types -- Object is required by React Native TurboModule codegen */
+export interface Spec extends TurboModule {
+  isStarted(): Promise<boolean>;
+  startNativeEmbraceSDK(config: Object): Promise<boolean>;
+  getDeviceId(): Promise<string>;
+  getLastRunEndState(): Promise<string>;
+  getCurrentSessionId(): Promise<string>;
+  setUserIdentifier(userIdentifier: string): Promise<boolean>;
+  setUsername(userName: string): Promise<boolean>;
+  setUserEmail(userEmail: string): Promise<boolean>;
+  clearUserIdentifier(): Promise<boolean>;
+  clearUsername(): Promise<boolean>;
+  clearUserEmail(): Promise<boolean>;
+  addBreadcrumb(event: string): Promise<boolean>;
+  addSessionProperty(
+    key: string,
+    value: string,
+    permanent: boolean,
+  ): Promise<boolean>;
+  removeSessionProperty(key: string): Promise<boolean>;
+  endSession(): Promise<boolean>;
+  setReactNativeSDKVersion(version: string): Promise<boolean>;
+  setReactNativeVersion(version: string): Promise<boolean>;
+  setJavaScriptPatchNumber(patch: string): Promise<boolean>;
+  setJavaScriptBundlePath(path: string): Promise<boolean>;
+  getDefaultJavaScriptBundlePath(): Promise<string>;
+  addUserPersona(persona: string): Promise<boolean>;
+  clearUserPersona(persona: string): Promise<boolean>;
+  clearAllUserPersonas(): Promise<boolean>;
+  logMessageWithSeverityAndProperties(
+    message: string,
+    severity: string,
+    properties: Object,
+    stacktrace: string,
+    includeStacktrace: boolean,
+  ): Promise<boolean>;
+  logHandledError(
+    message: string,
+    stacktrace: string,
+    properties: Object,
+  ): Promise<boolean>;
+  logUnhandledJSException(
+    name: string,
+    message: string,
+    type: string,
+    stacktrace: string,
+  ): Promise<boolean>;
+  logNetworkRequest(
+    url: string,
+    httpMethod: string,
+    startInMillis: number,
+    endInMillis: number,
+    bytesSent: number,
+    bytesReceived: number,
+    statusCode: number,
+  ): Promise<boolean>;
+  logNetworkClientError(
+    url: string,
+    httpMethod: string,
+    startInMillis: number,
+    endInMillis: number,
+    errorType: string,
+    errorMessage: string,
+  ): Promise<boolean>;
+}
+
+export default TurboModuleRegistry.get<Spec>("EmbraceManager");

--- a/packages/core/src/NativeEmbraceManager.ts
+++ b/packages/core/src/NativeEmbraceManager.ts
@@ -33,14 +33,14 @@ export interface Spec extends TurboModule {
   logMessageWithSeverityAndProperties(
     message: string,
     severity: string,
-    properties: Object,
+    properties: {[key: string]: string},
     stacktrace: string,
     includeStacktrace: boolean,
   ): Promise<boolean>;
   logHandledError(
     message: string,
     stacktrace: string,
-    properties: Object,
+    properties: {[key: string]: string},
   ): Promise<boolean>;
   logUnhandledJSException(
     name: string,

--- a/packages/core/src/__tests__/EmbraceManagerModule.test.ts
+++ b/packages/core/src/__tests__/EmbraceManagerModule.test.ts
@@ -1,0 +1,92 @@
+describe("EmbraceManagerModule resolution", () => {
+  const originalTurboModuleProxy = (global as any).__turboModuleProxy;
+
+  afterEach(() => {
+    (global as any).__turboModuleProxy = originalTurboModuleProxy;
+    jest.resetModules();
+  });
+
+  it("uses NativeModules when TurboModules are not available", () => {
+    delete (global as any).__turboModuleProxy;
+
+    jest.isolateModules(() => {
+      const mockNativeModule = {isStarted: jest.fn()};
+
+      jest.doMock("react-native", () => ({
+        NativeModules: {EmbraceManager: mockNativeModule},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeEmbraceManager", () => ({
+        default: {isStarted: jest.fn()},
+      }));
+
+      const {EmbraceManagerModule} =
+        require("../EmbraceManagerModule") as typeof import("../EmbraceManagerModule");
+
+      expect(EmbraceManagerModule).toBe(mockNativeModule);
+    });
+  });
+
+  it("uses TurboModule when TurboModules are available", () => {
+    (global as any).__turboModuleProxy = jest.fn();
+
+    jest.isolateModules(() => {
+      const mockTurboModule = {isStarted: jest.fn()};
+
+      jest.doMock("react-native", () => ({
+        NativeModules: {EmbraceManager: {isStarted: jest.fn()}},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeEmbraceManager", () => ({
+        default: mockTurboModule,
+      }));
+
+      const {EmbraceManagerModule} =
+        require("../EmbraceManagerModule") as typeof import("../EmbraceManagerModule");
+
+      expect(EmbraceManagerModule).toBe(mockTurboModule);
+    });
+  });
+
+  it("throws LINKING_ERROR when module is not available (Old Architecture)", () => {
+    delete (global as any).__turboModuleProxy;
+
+    jest.isolateModules(() => {
+      jest.doMock("react-native", () => ({
+        NativeModules: {EmbraceManager: undefined},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeEmbraceManager", () => ({
+        default: undefined,
+      }));
+
+      const {EmbraceManagerModule} =
+        require("../EmbraceManagerModule") as typeof import("../EmbraceManagerModule");
+
+      expect(() => {
+        (EmbraceManagerModule as any).someMethod;
+      }).toThrow("doesn't seem to be linked");
+    });
+  });
+
+  it("throws LINKING_ERROR when module is not available (New Architecture)", () => {
+    (global as any).__turboModuleProxy = jest.fn();
+
+    jest.isolateModules(() => {
+      jest.doMock("react-native", () => ({
+        NativeModules: {EmbraceManager: undefined},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeEmbraceManager", () => ({
+        default: null,
+      }));
+
+      const {EmbraceManagerModule} =
+        require("../EmbraceManagerModule") as typeof import("../EmbraceManagerModule");
+
+      expect(() => {
+        (EmbraceManagerModule as any).someMethod;
+      }).toThrow("doesn't seem to be linked");
+    });
+  });
+});

--- a/packages/react-native-otlp/android/build.gradle
+++ b/packages/react-native-otlp/android/build.gradle
@@ -58,11 +58,26 @@ android {
     }
   }
 
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += 'src/newarch/java'
+      } else {
+        java.srcDirs += 'src/oldarch/java'
+      }
+    }
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+  }
+
+  buildFeatures {
+    buildConfig true
   }
 
   buildTypes {

--- a/packages/react-native-otlp/android/src/main/java/io/embrace/rnembraceotlp/RNEmbraceOTLPModule.kt
+++ b/packages/react-native-otlp/android/src/main/java/io/embrace/rnembraceotlp/RNEmbraceOTLPModule.kt
@@ -8,7 +8,6 @@ import kotlin.time.toJavaDuration
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -33,8 +32,12 @@ data class OtlpExporterConfig (
     val logExporter: ExporterConfig? = null
 )
 
-class RNEmbraceOTLPModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
-    override fun getName() = "RNEmbraceOTLP"
+class RNEmbraceOTLPModule(reactContext: ReactApplicationContext) : RNEmbraceOTLPSpec(reactContext) {
+    override fun getName() = NAME
+
+    companion object {
+        const val NAME = "RNEmbraceOTLP"
+    }
 
     private val context: ReactApplicationContext = reactContext
     private val log = Logger.getLogger("[Embrace]")

--- a/packages/react-native-otlp/android/src/main/java/io/embrace/rnembraceotlp/RNEmbraceOTLPPackage.kt
+++ b/packages/react-native-otlp/android/src/main/java/io/embrace/rnembraceotlp/RNEmbraceOTLPPackage.kt
@@ -1,18 +1,33 @@
 package io.embrace.rnembraceotlp
 
-import android.view.View
-import com.facebook.react.ReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ReactShadowNode
-import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class RNEmbraceOTLPPackage : ReactPackage {
-    override fun createViewManagers(
-        reactContext: ReactApplicationContext
-    ): MutableList<ViewManager<View, ReactShadowNode<*>>> = mutableListOf()
+class RNEmbraceOTLPPackage : TurboReactPackage() {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+        return if (name == RNEmbraceOTLPModule.NAME) {
+            RNEmbraceOTLPModule(reactContext)
+        } else {
+            null
+        }
+    }
 
-    override fun createNativeModules(
-        reactContext: ReactApplicationContext
-    ): MutableList<NativeModule> = listOf(RNEmbraceOTLPModule(reactContext)).toMutableList()
+    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+        return ReactModuleInfoProvider {
+            val isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+            mapOf(
+                RNEmbraceOTLPModule.NAME to ReactModuleInfo(
+                    RNEmbraceOTLPModule.NAME,
+                    RNEmbraceOTLPModule.NAME,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    false, // isCxxModule
+                    isTurboModule // isTurboModule
+                )
+            )
+        }
+    }
 }

--- a/packages/react-native-otlp/android/src/newarch/java/io/embrace/rnembraceotlp/RNEmbraceOTLPSpec.kt
+++ b/packages/react-native-otlp/android/src/newarch/java/io/embrace/rnembraceotlp/RNEmbraceOTLPSpec.kt
@@ -1,0 +1,6 @@
+package io.embrace.rnembraceotlp
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class RNEmbraceOTLPSpec(reactContext: ReactApplicationContext) :
+    NativeRNEmbraceOTLPSpec(reactContext)

--- a/packages/react-native-otlp/android/src/oldarch/java/io/embrace/rnembraceotlp/RNEmbraceOTLPSpec.kt
+++ b/packages/react-native-otlp/android/src/oldarch/java/io/embrace/rnembraceotlp/RNEmbraceOTLPSpec.kt
@@ -1,0 +1,7 @@
+package io.embrace.rnembraceotlp
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+
+abstract class RNEmbraceOTLPSpec(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext)

--- a/packages/react-native-otlp/ios/RNEmbraceOTLP.mm
+++ b/packages/react-native-otlp/ios/RNEmbraceOTLP.mm
@@ -1,5 +1,9 @@
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNEmbraceOTLPSpec/RNEmbraceOTLPSpec.h>
+#endif
+
 @interface RCT_EXTERN_MODULE(RNEmbraceOTLP, NSObject)
 
 RCT_EXTERN_METHOD(startNativeEmbraceSDK:(NSDictionary)sdkConfig
@@ -13,3 +17,13 @@ RCT_EXTERN_METHOD(startNativeEmbraceSDK:(NSDictionary)sdkConfig
 }
 
 @end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+@implementation RNEmbraceOTLP (TurboModule)
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeRNEmbraceOTLPSpecJSI>(params);
+}
+@end
+#endif

--- a/packages/react-native-otlp/ios/RNEmbraceOTLP.swift
+++ b/packages/react-native-otlp/ios/RNEmbraceOTLP.swift
@@ -8,6 +8,10 @@ import OpenTelemetryProtocolExporterCommon
 import OpenTelemetryProtocolExporterHttp
 import OSLog
 
+#if RCT_NEW_ARCH_ENABLED
+import RNEmbraceOTLPSpec
+#endif
+
 @objc class RNExporterConfig: NSObject {
     var endpoint: String?
     var timeout: TimeInterval
@@ -154,3 +158,7 @@ class RNEmbraceOTLP: NSObject {
         }
     }
 }
+
+#if RCT_NEW_ARCH_ENABLED
+extension RNEmbraceOTLP: NativeRNEmbraceOTLPSpec {}
+#endif

--- a/packages/react-native-otlp/package.json
+++ b/packages/react-native-otlp/package.json
@@ -9,7 +9,8 @@
     "android/gradle.properties",
     "android/dependencies.gradle",
     "ios",
-    "RNEmbraceOTLP.podspec"
+    "RNEmbraceOTLP.podspec",
+    "src/NativeRNEmbraceOTLP.ts"
   ],
   "main": "lib/src/index.js",
   "typings": "lib/src/index.d.ts",
@@ -58,5 +59,13 @@
     "instrumentation",
     "telemetry",
     "bug tracker"
-  ]
+  ],
+  "codegenConfig": {
+    "name": "RNEmbraceOTLPSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "io.embrace.rnembraceotlp"
+    }
+  }
 }

--- a/packages/react-native-otlp/src/NativeRNEmbraceOTLP.ts
+++ b/packages/react-native-otlp/src/NativeRNEmbraceOTLP.ts
@@ -1,0 +1,12 @@
+import type {TurboModule} from "react-native";
+import {TurboModuleRegistry} from "react-native";
+
+/* eslint-disable @typescript-eslint/ban-types -- Object is required by React Native TurboModule codegen */
+export interface Spec extends TurboModule {
+  startNativeEmbraceSDK(
+    sdkConfig: Object,
+    otlpExporterConfig: Object,
+  ): Promise<boolean>;
+}
+
+export default TurboModuleRegistry.get<Spec>("RNEmbraceOTLP");

--- a/packages/react-native-otlp/src/__tests__/moduleResolution.test.ts
+++ b/packages/react-native-otlp/src/__tests__/moduleResolution.test.ts
@@ -1,0 +1,68 @@
+describe("OTLP module resolution", () => {
+  const originalTurboModuleProxy = (global as any).__turboModuleProxy;
+
+  afterEach(() => {
+    (global as any).__turboModuleProxy = originalTurboModuleProxy;
+    jest.resetModules();
+  });
+
+  it("uses NativeModules when TurboModules are not available", () => {
+    delete (global as any).__turboModuleProxy;
+
+    jest.isolateModules(() => {
+      const mockStartNativeEmbraceSDK = jest.fn().mockResolvedValue(true);
+      const mockNativeModule = {
+        startNativeEmbraceSDK: mockStartNativeEmbraceSDK,
+      };
+
+      jest.doMock("react-native", () => ({
+        NativeModules: {RNEmbraceOTLP: mockNativeModule},
+        Platform: {OS: "ios"},
+      }));
+      jest.doMock("../NativeRNEmbraceOTLP", () => ({
+        default: {startNativeEmbraceSDK: jest.fn()},
+      }));
+
+      const {initialize} =
+        require("../index") as typeof import("../index");
+
+      const callback = initialize({
+        logExporter: {endpoint: "https://example.com/logs/v1"},
+      });
+
+      callback({ios: {appId: "test"}});
+
+      expect(mockStartNativeEmbraceSDK).toHaveBeenCalled();
+    });
+  });
+
+  it("uses TurboModule when TurboModules are available", () => {
+    (global as any).__turboModuleProxy = jest.fn();
+
+    jest.isolateModules(() => {
+      const mockStartNativeEmbraceSDK = jest.fn().mockResolvedValue(true);
+      const mockTurboModule = {
+        startNativeEmbraceSDK: mockStartNativeEmbraceSDK,
+      };
+
+      jest.doMock("react-native", () => ({
+        NativeModules: {RNEmbraceOTLP: {startNativeEmbraceSDK: jest.fn()}},
+        Platform: {OS: "ios"},
+      }));
+      jest.doMock("../NativeRNEmbraceOTLP", () => ({
+        default: mockTurboModule,
+      }));
+
+      const {initialize} =
+        require("../index") as typeof import("../index");
+
+      const callback = initialize({
+        logExporter: {endpoint: "https://example.com/logs/v1"},
+      });
+
+      callback({ios: {appId: "test"}});
+
+      expect(mockStartNativeEmbraceSDK).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-native-otlp/src/__tests__/moduleResolution.test.ts
+++ b/packages/react-native-otlp/src/__tests__/moduleResolution.test.ts
@@ -23,8 +23,7 @@ describe("OTLP module resolution", () => {
         default: {startNativeEmbraceSDK: jest.fn()},
       }));
 
-      const {initialize} =
-        require("../index") as typeof import("../index");
+      const {initialize} = require("../index") as typeof import("../index");
 
       const callback = initialize({
         logExporter: {endpoint: "https://example.com/logs/v1"},
@@ -53,8 +52,7 @@ describe("OTLP module resolution", () => {
         default: mockTurboModule,
       }));
 
-      const {initialize} =
-        require("../index") as typeof import("../index");
+      const {initialize} = require("../index") as typeof import("../index");
 
       const callback = initialize({
         logExporter: {endpoint: "https://example.com/logs/v1"},

--- a/packages/react-native-otlp/src/index.ts
+++ b/packages/react-native-otlp/src/index.ts
@@ -3,6 +3,12 @@ import {NativeModules} from "react-native";
 
 import {AndroidConfig, IOSConfig, OTLPExporterConfig} from "./interfaces";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- standard React Native TurboModule detection
+const isTurboModuleEnabled = (global as any).__turboModuleProxy != null;
+const RNEmbraceOTLPModule = isTurboModuleEnabled
+  ? require("./NativeRNEmbraceOTLP").default
+  : NativeModules.RNEmbraceOTLP;
+
 const noOp = async (_: IOSConfig | AndroidConfig) => {};
 
 const WARN_MESSAGES = {
@@ -70,7 +76,7 @@ const initialize = (otlpExporterConfig: OTLPExporterConfig) => {
     try {
       // @embrace-io/react-native (core) is still handling the start
       // if an error occurs, the main package will print the proper errors
-      return await NativeModules.RNEmbraceOTLP.startNativeEmbraceSDK(
+      return await RNEmbraceOTLPModule.startNativeEmbraceSDK(
         sdkConfig,
         otlpExporterConfig,
       );

--- a/packages/react-native-tracer-provider/android/build.gradle
+++ b/packages/react-native-tracer-provider/android/build.gradle
@@ -58,11 +58,26 @@ android {
     }
   }
 
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += 'src/newarch/java'
+      } else {
+        java.srcDirs += 'src/oldarch/java'
+      }
+    }
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+  }
+
+  buildFeatures {
+    buildConfig true
   }
 
   buildTypes {

--- a/packages/react-native-tracer-provider/android/src/main/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderModule.kt
+++ b/packages/react-native-tracer-provider/android/src/main/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderModule.kt
@@ -2,7 +2,6 @@ package io.embrace.reactnativetracerprovider
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -49,7 +48,7 @@ private const val SPAN_STATUS_MESSAGE_KEY = "message"
 // Should not get hit under normal circumstances, add as a guard against misinstrumentation
 private const val MAX_STORED_SPANS = 10000
 
-class ReactNativeTracerProviderModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+class ReactNativeTracerProviderModule(reactContext: ReactApplicationContext) : ReactNativeTracerProviderSpec(reactContext) {
     private val log = Logger.getLogger("[Embrace]")
     private val tracers = ConcurrentHashMap<String, Tracer>()
     private val activeSpans = ConcurrentHashMap<String, Span>()
@@ -57,7 +56,11 @@ class ReactNativeTracerProviderModule(reactContext: ReactApplicationContext) : R
     private var tracerProvider: TracerProvider? = null
     private var writableMapBuilder: WritableMapBuilder
 
-    override fun getName() = "ReactNativeTracerProviderModule"
+    override fun getName() = NAME
+
+    companion object {
+        const val NAME = "ReactNativeTracerProviderModule"
+    }
 
     /**
      * Various deserializer helpers to go to and from the bridge Readable/Writable Array/Maps to

--- a/packages/react-native-tracer-provider/android/src/main/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderPackage.kt
+++ b/packages/react-native-tracer-provider/android/src/main/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderPackage.kt
@@ -1,18 +1,33 @@
 package io.embrace.reactnativetracerprovider
 
-import android.view.View
-import com.facebook.react.ReactPackage
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ReactShadowNode
-import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class ReactNativeTracerProviderPackage : ReactPackage {
-    override fun createViewManagers(
-        reactContext: ReactApplicationContext
-    ): MutableList<ViewManager<View, ReactShadowNode<*>>> = mutableListOf()
+class ReactNativeTracerProviderPackage : TurboReactPackage() {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+        return if (name == ReactNativeTracerProviderModule.NAME) {
+            ReactNativeTracerProviderModule(reactContext)
+        } else {
+            null
+        }
+    }
 
-    override fun createNativeModules(
-        reactContext: ReactApplicationContext
-    ): MutableList<NativeModule> = listOf(ReactNativeTracerProviderModule(reactContext)).toMutableList()
+    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+        return ReactModuleInfoProvider {
+            val isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+            mapOf(
+                ReactNativeTracerProviderModule.NAME to ReactModuleInfo(
+                    ReactNativeTracerProviderModule.NAME,
+                    ReactNativeTracerProviderModule.NAME,
+                    false, // canOverrideExistingModule
+                    false, // needsEagerInit
+                    false, // isCxxModule
+                    isTurboModule // isTurboModule
+                )
+            )
+        }
+    }
 }

--- a/packages/react-native-tracer-provider/android/src/newarch/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderSpec.kt
+++ b/packages/react-native-tracer-provider/android/src/newarch/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderSpec.kt
@@ -1,0 +1,6 @@
+package io.embrace.reactnativetracerprovider
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class ReactNativeTracerProviderSpec(reactContext: ReactApplicationContext) :
+    NativeReactNativeTracerProviderModuleSpec(reactContext)

--- a/packages/react-native-tracer-provider/android/src/oldarch/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderSpec.kt
+++ b/packages/react-native-tracer-provider/android/src/oldarch/java/io/embrace/reactnativetracerprovider/ReactNativeTracerProviderSpec.kt
@@ -1,0 +1,7 @@
+package io.embrace.reactnativetracerprovider
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+
+abstract class ReactNativeTracerProviderSpec(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext)

--- a/packages/react-native-tracer-provider/ios/ReactNativeTracerProviderModule.mm
+++ b/packages/react-native-tracer-provider/ios/ReactNativeTracerProviderModule.mm
@@ -1,5 +1,9 @@
 #import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNEmbraceTracerProviderSpec/RNEmbraceTracerProviderSpec.h>
+#endif
+
 @interface RCT_EXTERN_MODULE(ReactNativeTracerProviderModule, NSObject)
 
 RCT_EXTERN_METHOD(setupTracer:(NSString *)name version:(NSString *)version schemaUrl:(NSString *)schemaUrl)
@@ -26,3 +30,13 @@ RCT_EXTERN_METHOD(clearCompletedSpans)
 }
 
 @end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+@implementation ReactNativeTracerProviderModule (TurboModule)
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeReactNativeTracerProviderModuleSpecJSI>(params);
+}
+@end
+#endif

--- a/packages/react-native-tracer-provider/ios/ReactNativeTracerProviderModule.swift
+++ b/packages/react-native-tracer-provider/ios/ReactNativeTracerProviderModule.swift
@@ -5,6 +5,10 @@ import EmbraceIO
 import OpenTelemetryApi
 import os
 
+#if RCT_NEW_ARCH_ENABLED
+import RNEmbraceTracerProviderSpec
+#endif
+
 /*
  NOTE: There's currently a bit of duplication between this and code in packages/core, particularly https://github.com/embrace-io/embrace-react-native-sdk/blob/7c54b59362adfc93f7f997db89db179950a50e8b/packages/core/ios/RNEmbraceCore/SpanRepository.swift
  
@@ -331,3 +335,7 @@ class ReactNativeTracerProviderModule: NSObject {
     }
   }
  }
+
+#if RCT_NEW_ARCH_ENABLED
+extension ReactNativeTracerProviderModule: NativeReactNativeTracerProviderModuleSpec {}
+#endif

--- a/packages/react-native-tracer-provider/package.json
+++ b/packages/react-native-tracer-provider/package.json
@@ -12,7 +12,8 @@
     "android/gradle.properties",
     "android/dependencies.gradle",
     "ios",
-    "RNEmbraceTracerProvider.podspec"
+    "RNEmbraceTracerProvider.podspec",
+    "src/NativeReactNativeTracerProviderModule.ts"
   ],
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {
@@ -62,5 +63,13 @@
   "embrace": {
     "iosVersion": "6.16.2",
     "androidVersion": "7.9.2"
+  },
+  "codegenConfig": {
+    "name": "RNEmbraceTracerProviderSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "io.embrace.reactnativetracerprovider"
+    }
   }
 }

--- a/packages/react-native-tracer-provider/src/NativeReactNativeTracerProviderModule.ts
+++ b/packages/react-native-tracer-provider/src/NativeReactNativeTracerProviderModule.ts
@@ -1,0 +1,33 @@
+import type {TurboModule} from "react-native";
+import {TurboModuleRegistry} from "react-native";
+
+/* eslint-disable @typescript-eslint/ban-types -- Object is required by React Native TurboModule codegen */
+export interface Spec extends TurboModule {
+  setupTracer(name: string, version: string, schemaUrl: string): void;
+  startSpan(
+    tracerName: string,
+    tracerVersion: string,
+    tracerSchemaUrl: string,
+    spanBridgeId: string,
+    name: string,
+    kind: string,
+    time: number,
+    attributes: Object,
+    links: Object[],
+    parentId: string,
+  ): Promise<Object>;
+  setAttributes(spanBridgeId: string, attributes: Object): void;
+  addEvent(
+    spanBridgeId: string,
+    eventName: string,
+    attributes: Object,
+    time: number,
+  ): void;
+  addLinks(spanBridgeId: string, links: Object[]): void;
+  setStatus(spanBridgeId: string, status: Object): void;
+  updateName(spanBridgeId: string, name: string): void;
+  endSpan(spanBridgeId: string, time: number): void;
+  clearCompletedSpans(): void;
+}
+
+export default TurboModuleRegistry.get<Spec>("ReactNativeTracerProviderModule");

--- a/packages/react-native-tracer-provider/src/TracerProviderModule.ts
+++ b/packages/react-native-tracer-provider/src/TracerProviderModule.ts
@@ -6,8 +6,15 @@ const LINKING_ERROR =
   "- You rebuilt the app after installing the package\n" +
   "- You are not using Expo Go\n";
 
-const TracerProviderModule = NativeModules.ReactNativeTracerProviderModule
-  ? NativeModules.ReactNativeTracerProviderModule
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- standard React Native TurboModule detection
+const isTurboModuleEnabled = (global as any).__turboModuleProxy != null;
+
+const NativeModule = isTurboModuleEnabled
+  ? require("./NativeReactNativeTracerProviderModule").default
+  : NativeModules.ReactNativeTracerProviderModule;
+
+const TracerProviderModule = NativeModule
+  ? NativeModule
   : new Proxy(
       {},
       {

--- a/packages/react-native-tracer-provider/src/__tests__/TracerProviderModule.test.ts
+++ b/packages/react-native-tracer-provider/src/__tests__/TracerProviderModule.test.ts
@@ -1,0 +1,94 @@
+describe("TracerProviderModule resolution", () => {
+  const originalTurboModuleProxy = (global as any).__turboModuleProxy;
+
+  afterEach(() => {
+    (global as any).__turboModuleProxy = originalTurboModuleProxy;
+    jest.resetModules();
+  });
+
+  it("uses NativeModules when TurboModules are not available", () => {
+    delete (global as any).__turboModuleProxy;
+
+    jest.isolateModules(() => {
+      const mockNativeModule = {setupTracer: jest.fn()};
+
+      jest.doMock("react-native", () => ({
+        NativeModules: {ReactNativeTracerProviderModule: mockNativeModule},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeReactNativeTracerProviderModule", () => ({
+        default: {setupTracer: jest.fn()},
+      }));
+
+      const {TracerProviderModule} =
+        require("../TracerProviderModule") as typeof import("../TracerProviderModule");
+
+      expect(TracerProviderModule).toBe(mockNativeModule);
+    });
+  });
+
+  it("uses TurboModule when TurboModules are available", () => {
+    (global as any).__turboModuleProxy = jest.fn();
+
+    jest.isolateModules(() => {
+      const mockTurboModule = {setupTracer: jest.fn()};
+
+      jest.doMock("react-native", () => ({
+        NativeModules: {
+          ReactNativeTracerProviderModule: {setupTracer: jest.fn()},
+        },
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeReactNativeTracerProviderModule", () => ({
+        default: mockTurboModule,
+      }));
+
+      const {TracerProviderModule} =
+        require("../TracerProviderModule") as typeof import("../TracerProviderModule");
+
+      expect(TracerProviderModule).toBe(mockTurboModule);
+    });
+  });
+
+  it("throws LINKING_ERROR when module is not available (Old Architecture)", () => {
+    delete (global as any).__turboModuleProxy;
+
+    jest.isolateModules(() => {
+      jest.doMock("react-native", () => ({
+        NativeModules: {ReactNativeTracerProviderModule: undefined},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeReactNativeTracerProviderModule", () => ({
+        default: undefined,
+      }));
+
+      const {TracerProviderModule} =
+        require("../TracerProviderModule") as typeof import("../TracerProviderModule");
+
+      expect(() => {
+        (TracerProviderModule as any).someMethod;
+      }).toThrow("doesn't seem to be linked");
+    });
+  });
+
+  it("throws LINKING_ERROR when module is not available (New Architecture)", () => {
+    (global as any).__turboModuleProxy = jest.fn();
+
+    jest.isolateModules(() => {
+      jest.doMock("react-native", () => ({
+        NativeModules: {ReactNativeTracerProviderModule: undefined},
+        Platform: {select: jest.fn(() => "")},
+      }));
+      jest.doMock("../NativeReactNativeTracerProviderModule", () => ({
+        default: null,
+      }));
+
+      const {TracerProviderModule} =
+        require("../TracerProviderModule") as typeof import("../TracerProviderModule");
+
+      expect(() => {
+        (TracerProviderModule as any).someMethod;
+      }).toThrow("doesn't seem to be linked");
+    });
+  });
+});


### PR DESCRIPTION
Add React Native New Architecture (TurboModules) support to core, react-native-otlp, and react-native-tracer-provider while maintaining backward compatibility with the Old Architecture bridge modules.

- Add codegen spec files (NativeXxx.ts) for each package
- Add codegenConfig to each package.json
- Use TurboModuleRegistry with NativeModules fallback on JS side
- Add oldarch/newarch Android source sets with spec adapter classes
- Convert Android packages from ReactPackage to TurboReactPackage
- Rename iOS bridge files .m → .mm and add getTurboModule: categories
- Add Swift protocol conformance behind RCT_NEW_ARCH_ENABLED flag

## Notion ticket

https://www.notion.so/embraceio/Rewrite-packages-using-New-Architecture-c86220741f4244b2b79b36f38d349d0b

## Goal

Rewrite packages to integrate and fully utilize New Architecture

## Testing

Local testing and CI testing

## Release Notes

Full support for New Architecture with fallback