### PR TITLE
[EMBR-11700] Expo Config Plugin: "Upload Debug Symbols" build phase references non-existent ${PODS_ROOT}/EmbraceIO/run.sh

### DIFF
--- a/packages/core/ios/scripts/run.sh
+++ b/packages/core/ios/scripts/run.sh
@@ -105,7 +105,7 @@ function log_warning () {
 function run() {
     if [ -z "$EMBRACE_DEBUG_DSYM" ] ; then
         # we must redirect both stdout and stderr to /dev/null to have Xcode run this script in the background and move on to other build tasks
-	eval "$1 --log-path \"$BUILD_ROOT\"" > /dev/null 2>&1 &
+	eval "$1 --log-path $BUILD_ROOT" > /dev/null 2>&1 &
     else
         eval "$1"
     fi
@@ -190,7 +190,7 @@ function react_native_upload() {
     if [ -n "$react_args" ] ; then
         log "uploading react native resources with bundle at ${react_bundle_path} and map at ${react_map_path}"
         # shellcheck disable=2153
-        run "\"$UPLOAD_BIN_PATH\" --app \"$EMBRACE_ID\" --token \"$EMBRACE_TOKEN\" $react_args $host_arg --log-level $EMBRACE_LOG_LEVEL"
+        run "\"$UPLOAD_BIN_PATH\" --app $EMBRACE_ID --token $EMBRACE_TOKEN $react_args $host_arg --log-level $EMBRACE_LOG_LEVEL"
     fi
 }
 
@@ -270,7 +270,7 @@ function upload() {
         else
           icon_arg=""
         fi
-        run "\"$UPLOAD_BIN_PATH\" --app \"$EMBRACE_ID\" --token \"$EMBRACE_TOKEN\" $unity_args $icon_arg $app_version_arg $host_arg --dsym \"$app_dsym_file\" --log-level $EMBRACE_LOG_LEVEL"
+        run "\"$UPLOAD_BIN_PATH\" --app $EMBRACE_ID --token $EMBRACE_TOKEN $unity_args $icon_arg $app_version_arg $host_arg --dsym \"$app_dsym_file\" --log-level $EMBRACE_LOG_LEVEL"
     else
         log_warning "No app dSYM file was found under BUILD_ROOT ${BUILD_ROOT}. Skipping upload."
     fi
@@ -321,7 +321,7 @@ function upload() {
             log "Queueing framework dSYM for upload: $dsym_full_path"
         done
         IFS=$ORIG_IFS
-        run "\"$UPLOAD_BIN_PATH\" --app \"$EMBRACE_ID\" --token \"$EMBRACE_TOKEN\" $dsym_args $app_version_arg $host_arg --log-level $EMBRACE_LOG_LEVEL"
+        run "\"$UPLOAD_BIN_PATH\" --app $EMBRACE_ID --token $EMBRACE_TOKEN $dsym_args $app_version_arg $host_arg --log-level $EMBRACE_LOG_LEVEL"
     fi
 }
 

--- a/packages/core/ios/scripts/run.sh
+++ b/packages/core/ios/scripts/run.sh
@@ -105,14 +105,18 @@ function log_warning () {
 function run() {
     if [ -z "$EMBRACE_DEBUG_DSYM" ] ; then
         # we must redirect both stdout and stderr to /dev/null to have Xcode run this script in the background and move on to other build tasks
-	eval "$1 --log-path $BUILD_ROOT" > /dev/null 2>&1 &
+	eval "$1 --log-path \"$BUILD_ROOT\"" > /dev/null 2>&1 &
     else
         eval "$1"
     fi
 }
 
 function createSourceMap() {
-  REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  REACT_NATIVE_DIR="$(dirname "${BASH_SOURCE[0]}")"
+  while [ "$REACT_NATIVE_DIR" != "/" ]; do
+    [ -f "$REACT_NATIVE_DIR/node_modules/react-native/cli.js" ] && break
+    REACT_NATIVE_DIR="$(dirname "$REACT_NATIVE_DIR")"
+  done
   CLI_PATH="$REACT_NATIVE_DIR/node_modules/react-native/cli.js"
 
   DEST=/dev/null
@@ -186,7 +190,7 @@ function react_native_upload() {
     if [ -n "$react_args" ] ; then
         log "uploading react native resources with bundle at ${react_bundle_path} and map at ${react_map_path}"
         # shellcheck disable=2153
-        run "\"$UPLOAD_BIN_PATH\" --app $EMBRACE_ID --token $EMBRACE_TOKEN $react_args $host_arg --log-level $EMBRACE_LOG_LEVEL"
+        run "\"$UPLOAD_BIN_PATH\" --app \"$EMBRACE_ID\" --token \"$EMBRACE_TOKEN\" $react_args $host_arg --log-level $EMBRACE_LOG_LEVEL"
     fi
 }
 
@@ -266,7 +270,7 @@ function upload() {
         else
           icon_arg=""
         fi
-        run "\"$UPLOAD_BIN_PATH\" --app $EMBRACE_ID --token $EMBRACE_TOKEN $unity_args $icon_arg $app_version_arg $host_arg --dsym \"$app_dsym_file\" --log-level $EMBRACE_LOG_LEVEL"
+        run "\"$UPLOAD_BIN_PATH\" --app \"$EMBRACE_ID\" --token \"$EMBRACE_TOKEN\" $unity_args $icon_arg $app_version_arg $host_arg --dsym \"$app_dsym_file\" --log-level $EMBRACE_LOG_LEVEL"
     else
         log_warning "No app dSYM file was found under BUILD_ROOT ${BUILD_ROOT}. Skipping upload."
     fi
@@ -317,7 +321,7 @@ function upload() {
             log "Queueing framework dSYM for upload: $dsym_full_path"
         done
         IFS=$ORIG_IFS
-        run "\"$UPLOAD_BIN_PATH\" --app $EMBRACE_ID --token $EMBRACE_TOKEN $dsym_args $app_version_arg $host_arg --log-level $EMBRACE_LOG_LEVEL"
+        run "\"$UPLOAD_BIN_PATH\" --app \"$EMBRACE_ID\" --token \"$EMBRACE_TOKEN\" $dsym_args $app_version_arg $host_arg --log-level $EMBRACE_LOG_LEVEL"
     fi
 }
 

--- a/packages/core/ios/scripts/run.sh
+++ b/packages/core/ios/scripts/run.sh
@@ -112,12 +112,22 @@ function run() {
 }
 
 function createSourceMap() {
-  REACT_NATIVE_DIR="$(dirname "${BASH_SOURCE[0]}")"
+  REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+  # Walk up the tree to find the app's react-native CLI
+  CLI_PATH=""
   while [ "$REACT_NATIVE_DIR" != "/" ]; do
-    [ -f "$REACT_NATIVE_DIR/node_modules/react-native/cli.js" ] && break
+    if [ -f "$REACT_NATIVE_DIR/node_modules/react-native/cli.js" ]; then
+      CLI_PATH="$REACT_NATIVE_DIR/node_modules/react-native/cli.js"
+      break
+    fi
     REACT_NATIVE_DIR="$(dirname "$REACT_NATIVE_DIR")"
   done
-  CLI_PATH="$REACT_NATIVE_DIR/node_modules/react-native/cli.js"
+
+  if [ -z "$CLI_PATH" ]; then
+    log_warning "Could not find react-native CLI above ${BASH_SOURCE[0]}. Skipping source map generation."
+    return
+  fi
 
   DEST=/dev/null
 

--- a/packages/core/scripts/__tests__/__mocks__/ios/hasBridgingHeader.xcodeproj/project.pbxproj
+++ b/packages/core/scripts/__tests__/__mocks__/ios/hasBridgingHeader.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/main.jsbundle.map\" EMBRACE_ID=appid EMBRACE_TOKEN=test \"${PODS_ROOT}/EmbraceIO/run.sh\"";
+			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/main.jsbundle.map\" EMBRACE_ID=appid EMBRACE_TOKEN=test \"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"";
 		};
 		A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/core/scripts/__tests__/__mocks__/ios/hasProductModuleName.xcodeproj/project.pbxproj
+++ b/packages/core/scripts/__tests__/__mocks__/ios/hasProductModuleName.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/main.jsbundle.map\" EMBRACE_ID=appid EMBRACE_TOKEN=test \"${PODS_ROOT}/EmbraceIO/run.sh\"";
+			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/main.jsbundle.map\" EMBRACE_ID=appid EMBRACE_TOKEN=test \"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"";
 		};
 		A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/core/scripts/__tests__/__mocks__/ios/testMock.xcodeproj/project.pbxproj
+++ b/packages/core/scripts/__tests__/__mocks__/ios/testMock.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=abcde EMBRACE_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \"$SRCROOT/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"";
+			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=abcde EMBRACE_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"";
 		};
 		A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/core/scripts/util/ios.ts
+++ b/packages/core/scripts/util/ios.ts
@@ -16,7 +16,7 @@ const LOGGER = new EmbraceLogger(console);
 const UPLOAD_SYMBOLS_PHASE = "Embrace Symbol Uploads";
 const EMBRACE_INIT_OBJECTIVEC = "[EmbraceInitializer start];";
 const EMBR_RUN_SCRIPT =
-  '"$SRCROOT/../node_modules/@embrace-io/react-native/ios/scripts/run.sh"';
+  '"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh"';
 const EMBR_NATIVE_POD = `pod 'EmbraceIO'`;
 const EMBR_KSCRASH_MODULAR_HEADER_POD = `
 # [Embrace] Make KSCrash modular so Swift can import it 

--- a/packages/core/src/__tests__/__plugin_mocks__/xcodeprojWithEmbraceBuildPhase.pbxproj
+++ b/packages/core/src/__tests__/__plugin_mocks__/xcodeprojWithEmbraceBuildPhase.pbxproj
@@ -365,7 +365,7 @@
 			outputPaths = (
 			);
 			shellPath = /bin/sh;
-			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${PODS_ROOT}/EmbraceIO/run.sh\"";
+			shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/core/src/plugin/textUtils.ts
+++ b/packages/core/src/plugin/textUtils.ts
@@ -1,5 +1,5 @@
-const hasMatch = (lines: string[], matcher: string) => {
-  return lines.find(line => line.match(matcher));
+const hasMatch = (lines: string[], substring: string) => {
+  return lines.find(line => line.includes(substring));
 };
 
 const addAfter = (lines: string[], matcher: RegExp, toAdd: string) => {

--- a/packages/core/src/plugin/withIosEmbrace.ts
+++ b/packages/core/src/plugin/withIosEmbrace.ts
@@ -28,6 +28,8 @@ const sourceMapPath =
   "$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map";
 const exportSourcemapLine = `export SOURCEMAP_FILE="${sourceMapPath}"`;
 const ksCrashConfig = `pod 'KSCrash', :modular_headers => true`;
+const embraceLegacyRunScriptPath = "EmbraceIO/run.sh";
+const embraceRunScriptPath = "@embrace-io/react-native/ios/scripts/run.sh";
 
 const withIosEmbraceAddKSCrashPod: ConfigPlugin = expoConfig => {
   return withDangerousMod(expoConfig, [
@@ -297,8 +299,8 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
     shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"\nrm \"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\"";
      */
     if (
-      !findPhase(project, "EmbraceIO/run.sh") &&
-      !findPhase(project, "embrace-io/react-native/ios/scripts/run.sh")
+      !findPhase(project, embraceLegacyRunScriptPath) &&
+      !findPhase(project, embraceRunScriptPath)
     ) {
       project.addBuildPhase(
         [],
@@ -307,7 +309,7 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
         null,
         {
           shellPath: "/bin/sh",
-          shellScript: `REACT_NATIVE_MAP_PATH="${sourceMapPath}" EMBRACE_ID=${props.iOSAppId} EMBRACE_TOKEN=${props.apiToken} "\${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh"`,
+          shellScript: `REACT_NATIVE_MAP_PATH="${sourceMapPath}" EMBRACE_ID=${props.iOSAppId} EMBRACE_TOKEN=${props.apiToken} "\${SRCROOT}/../node_modules/${embraceRunScriptPath}"`,
         },
       );
       modified = true;

--- a/packages/core/src/plugin/withIosEmbrace.ts
+++ b/packages/core/src/plugin/withIosEmbrace.ts
@@ -29,7 +29,7 @@ const sourceMapPath =
 const exportSourcemapLine = `export SOURCEMAP_FILE="${sourceMapPath}"`;
 const ksCrashConfig = `pod 'KSCrash', :modular_headers => true`;
 const embraceLegacyRunScriptPath = "EmbraceIO/run.sh";
-const embraceRunScriptPath = "@embrace-io/react-native/ios/scripts/run.sh";
+const embraceRunScriptPath = "${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh";
 
 const withIosEmbraceAddKSCrashPod: ConfigPlugin = expoConfig => {
   return withDangerousMod(expoConfig, [
@@ -309,7 +309,7 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
         null,
         {
           shellPath: "/bin/sh",
-          shellScript: `REACT_NATIVE_MAP_PATH="${sourceMapPath}" EMBRACE_ID=${props.iOSAppId} EMBRACE_TOKEN=${props.apiToken} "\${SRCROOT}/../node_modules/${embraceRunScriptPath}"`,
+          shellScript: `REACT_NATIVE_MAP_PATH="${sourceMapPath}" EMBRACE_ID=${props.iOSAppId} EMBRACE_TOKEN=${props.apiToken} "${embraceRunScriptPath}"`,
         },
       );
       modified = true;

--- a/packages/core/src/plugin/withIosEmbrace.ts
+++ b/packages/core/src/plugin/withIosEmbrace.ts
@@ -296,7 +296,10 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
     /*
     shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${PODS_ROOT}/EmbraceIO/run.sh\"\nrm \"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\"";
      */
-    if (!findPhase(project, "EmbraceIO/run.sh") && !findPhase(project, "embrace-io/react-native/ios/scripts/run.sh")) {
+    if (
+      !findPhase(project, "EmbraceIO/run.sh") &&
+      !findPhase(project, "embrace-io/react-native/ios/scripts/run.sh")
+    ) {
       project.addBuildPhase(
         [],
         "PBXShellScriptBuildPhase",

--- a/packages/core/src/plugin/withIosEmbrace.ts
+++ b/packages/core/src/plugin/withIosEmbrace.ts
@@ -294,7 +294,7 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
     }
 
     /*
-    shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${PODS_ROOT}/EmbraceIO/run.sh\"\nrm \"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\"";
+    shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh\"\nrm \"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\"";
      */
     if (
       !findPhase(project, "EmbraceIO/run.sh") &&

--- a/packages/core/src/plugin/withIosEmbrace.ts
+++ b/packages/core/src/plugin/withIosEmbrace.ts
@@ -29,7 +29,8 @@ const sourceMapPath =
 const exportSourcemapLine = `export SOURCEMAP_FILE="${sourceMapPath}"`;
 const ksCrashConfig = `pod 'KSCrash', :modular_headers => true`;
 const embraceLegacyRunScriptPath = "EmbraceIO/run.sh";
-const embraceRunScriptPath = "${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh";
+const embraceRunScriptPath =
+  "${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh";
 
 const withIosEmbraceAddKSCrashPod: ConfigPlugin = expoConfig => {
   return withDangerousMod(expoConfig, [

--- a/packages/core/src/plugin/withIosEmbrace.ts
+++ b/packages/core/src/plugin/withIosEmbrace.ts
@@ -296,7 +296,7 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
     /*
     shellScript = "REACT_NATIVE_MAP_PATH=\"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\" EMBRACE_ID=ios789 EMBRACE_TOKEN=apiToken456 \"${PODS_ROOT}/EmbraceIO/run.sh\"\nrm \"$CONFIGURATION_BUILD_DIR/embrace-assets/main.jsbundle.map\"";
      */
-    if (!findPhase(project, "EmbraceIO/run.sh")) {
+    if (!findPhase(project, "EmbraceIO/run.sh") && !findPhase(project, "embrace-io/react-native/ios/scripts/run.sh")) {
       project.addBuildPhase(
         [],
         "PBXShellScriptBuildPhase",
@@ -304,7 +304,7 @@ const withIosEmbraceAddUploadPhase: ConfigPlugin<EmbraceProps> = (
         null,
         {
           shellPath: "/bin/sh",
-          shellScript: `REACT_NATIVE_MAP_PATH="${sourceMapPath}" EMBRACE_ID=${props.iOSAppId} EMBRACE_TOKEN=${props.apiToken} "\${PODS_ROOT}/EmbraceIO/run.sh"`,
+          shellScript: `REACT_NATIVE_MAP_PATH="${sourceMapPath}" EMBRACE_ID=${props.iOSAppId} EMBRACE_TOKEN=${props.apiToken} "\${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh"`,
         },
       );
       modified = true;


### PR DESCRIPTION
## Goal

Fixes #776 - the `run.sh` script location has changed but the expo config plugin was still adding a build phase script using the old location.

Also fixes the fallback `createSourceMap` function in the `run.sh` script itself which also assumed the old script location - it now attempts to traverse up from the script directory until it finds the RN CLI and only tries to invoke the CLI if it finds it.

## Testing

Updated unit tests + tested manually with an Expo project