### PR TITLE
ci: update browserstack android device

### DIFF
--- a/integration-tests/browserstack.conf.ts
+++ b/integration-tests/browserstack.conf.ts
@@ -14,8 +14,8 @@ const androidCapabilities = [
   },
   {
     "bstack:options": {
-      deviceName: "Samsung Galaxy S10",
-      platformVersion: "9.0",
+      deviceName: "Samsung Galaxy S20",
+      platformVersion: "10.0",
       platformName: "android",
     },
   },


### PR DESCRIPTION
## Goal

Browserstack have recently deprecated Samsung Galaxy S10, so Android integration tests are now failing to run. This updates the browserstack config to use the closest available device (Samsung Galaxy S20)

## Testing

Manually triggered integration tests to confirm they now pass

