### PR TITLE
ci: disable package manager cache in prepare-release.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning] - job doesn't produce published artifacts
         with:
           node-version-file: ".node-version"
-          cache: 'yarn'
+          package-manager-cache: false
 
       - name: Enable Corepack (Yarn 4)
         run: corepack enable


### PR DESCRIPTION
## Goal

Fixes an issue with the prepare-release workflow - `cache: 'yarn'` makes `actions/setup-node` run yarn cache dir during its own step, before corepack enable runs, which causes the step to fail.

 Replaced `cache: 'yarn'` with `package-manager-cache: false`, disabling the pre-Corepack yarn probe.
