### PR TITLE
[EMBR-12628] Update embrace-android-sdk from 7.9.2 to 8.4.0

### DIFF
--- a/NATIVE_MODULE_DEVELOPING.md
+++ b/NATIVE_MODULE_DEVELOPING.md
@@ -161,8 +161,8 @@ Tests can be run from XCode by opening test-project/ios/RNEmbrace<PackageName>Te
 - Replace content of app/build.gradle.kts with proper configuration (using as example what other packages)
 - Make sure `app/build.gradle.kts` includes the right local package (implemented in `settings.gradle`)
 - Make sure `apply("../../../android/dependencies.gradle")` is added into `app/build.gradle.kts`
-- Make sure `android/gradle/wrapper/gradle-wrapper.properties` points to a gradle version we support (7.5.1 atm)
-- Make sure `android/build.gradle` includes an AGP we support (com.android.tools.build:gradle:7.4.2 atm)
+- Make sure `android/gradle/wrapper/gradle-wrapper.properties` points to a gradle version we support (8.0.2 atm)
+- Make sure `android/build.gradle` includes an AGP we support (com.android.tools.build:gradle:8.0.2 atm)
 
 Tests can be run from Android Studio by adding test-project/android as a Project or from the CLI with `yarn android:test`.
 

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.4.2"
+    classpath "com.android.tools.build:gradle:8.0.2"
     // NOTE: to pull `emb_android_sdk` version from package.json instead in a future iteration
     classpath "io.embrace:embrace-swazzler:$emb_android_sdk"
     // noinspection DifferentKotlinGradleVersion

--- a/packages/core/android/gradle.properties
+++ b/packages/core/android/gradle.properties
@@ -1,6 +1,6 @@
 android.useAndroidX=true
 
-emb_android_sdk=7.9.2
+emb_android_sdk=8.4.0
 
 RNEmbraceCore_packageJsonPath=..
 

--- a/packages/core/android/gradle.properties
+++ b/packages/core/android/gradle.properties
@@ -4,7 +4,7 @@ emb_android_sdk=8.4.0
 
 RNEmbraceCore_packageJsonPath=..
 
-RNEmbraceCore_kotlinVersion=1.8.20
+RNEmbraceCore_kotlinVersion=2.0.21
 RNEmbraceCore_minSdkVersion=24
 RNEmbraceCore_targetSdkVersion=34
 RNEmbraceCore_compileSdkVersion=34

--- a/packages/core/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/core/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,6 @@
   },
   "embrace": {
     "iosVersion": "6.19.0",
-    "androidVersion": "7.9.2"
+    "androidVersion": "8.4.0"
   }
 }

--- a/packages/core/test-project/android/gradle.properties
+++ b/packages/core/test-project/android/gradle.properties
@@ -38,7 +38,7 @@ newArchEnabled=true
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
 
-RNEmbraceCore_kotlinVersion=1.8.20
+RNEmbraceCore_kotlinVersion=2.0.21
 RNEmbraceCore_minSdkVersion=21
 RNEmbraceCore_targetSdkVersion=31
 RNEmbraceCore_compileSdkVersion=31

--- a/packages/react-native-navigation/package.json
+++ b/packages/react-native-navigation/package.json
@@ -39,7 +39,7 @@
   },
   "embrace": {
     "iosVersion": "6.19.0",
-    "androidVersion": "7.9.2"
+    "androidVersion": "8.4.0"
   },
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/react-native-otlp/android/build.gradle
+++ b/packages/react-native-otlp/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.4.2"
+    classpath "com.android.tools.build:gradle:8.0.2"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }

--- a/packages/react-native-otlp/android/gradle.properties
+++ b/packages/react-native-otlp/android/gradle.properties
@@ -3,7 +3,7 @@ android.useAndroidX=true
 
 RNEmbraceOTLP_packageJsonPath=..
 
-RNEmbraceOTLP_kotlinVersion=1.8.20
+RNEmbraceOTLP_kotlinVersion=2.0.21
 RNEmbraceOTLP_minSdkVersion=24
 RNEmbraceOTLP_targetSdkVersion=34
 RNEmbraceOTLP_compileSdkVersion=34

--- a/packages/react-native-otlp/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-otlp/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/react-native-otlp/package.json
+++ b/packages/react-native-otlp/package.json
@@ -33,7 +33,7 @@
   },
   "embrace": {
     "iosVersion": "6.19.0",
-    "androidVersion": "7.9.2"
+    "androidVersion": "8.4.0"
   },
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/packages/react-native-otlp/test-project/android/gradle.properties
+++ b/packages/react-native-otlp/test-project/android/gradle.properties
@@ -38,7 +38,7 @@ newArchEnabled=true
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
 
-RNEmbraceOTLP_kotlinVersion=1.8.20
+RNEmbraceOTLP_kotlinVersion=2.0.21
 RNEmbraceOTLP_minSdkVersion=21
 RNEmbraceOTLP_targetSdkVersion=31
 RNEmbraceOTLP_compileSdkVersion=31

--- a/packages/react-native-redux/package.json
+++ b/packages/react-native-redux/package.json
@@ -56,6 +56,6 @@
   },
   "embrace": {
     "iosVersion": "6.19.0",
-    "androidVersion": "7.9.2"
+    "androidVersion": "8.4.0"
   }
 }

--- a/packages/react-native-tracer-provider/android/build.gradle
+++ b/packages/react-native-tracer-provider/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.4.2"
+    classpath "com.android.tools.build:gradle:8.0.2"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }

--- a/packages/react-native-tracer-provider/android/gradle.properties
+++ b/packages/react-native-tracer-provider/android/gradle.properties
@@ -2,7 +2,7 @@ android.useAndroidX=true
 
 RNEmbraceTracerProvider_packageJsonPath=..
 
-RNEmbraceTracerProvider_kotlinVersion=1.8.20
+RNEmbraceTracerProvider_kotlinVersion=2.0.21
 RNEmbraceTracerProvider_minSdkVersion=24
 RNEmbraceTracerProvider_targetSdkVersion=34
 RNEmbraceTracerProvider_compileSdkVersion=34

--- a/packages/react-native-tracer-provider/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-tracer-provider/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/react-native-tracer-provider/package.json
+++ b/packages/react-native-tracer-provider/package.json
@@ -61,6 +61,6 @@
   },
   "embrace": {
     "iosVersion": "6.19.0",
-    "androidVersion": "7.9.2"
+    "androidVersion": "8.4.0"
   }
 }

--- a/packages/react-native-tracer-provider/test-project/android/gradle.properties
+++ b/packages/react-native-tracer-provider/test-project/android/gradle.properties
@@ -38,7 +38,7 @@ newArchEnabled=true
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
 
-RNEmbraceTracerProvider_kotlinVersion=1.8.20
+RNEmbraceTracerProvider_kotlinVersion=2.0.21
 RNEmbraceTracerProvider_minSdkVersion=21
 RNEmbraceTracerProvider_targetSdkVersion=31
 RNEmbraceTracerProvider_compileSdkVersion=31

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -128,7 +128,7 @@ function enforceEmbraceMetadata({Yarn}) {
 
     workspace.set("embrace", {
       iosVersion: "6.19.0",
-      androidVersion: "7.9.2",
+      androidVersion: "8.4.0",
     });
   }
 }


### PR DESCRIPTION
## Goal

Initial PR to update the Android SDK to [v8.4.0](https://github.com/embrace-io/embrace-android-sdk/releases/tag/8.4.0)

The Android tests are expected to fail at this stage and will be fixed in subsequent PRs
