### PR TITLE
[EMBR-12632] Update react-native-otlp package for android sdk v8.4.0

### DIFF
--- a/packages/react-native-otlp/README.md
+++ b/packages/react-native-otlp/README.md
@@ -153,10 +153,17 @@ let GRAFANA_LOGS_ENDPOINT = "https://otlp-gateway-prod-us-central-0.grafana.net/
 Similar to iOS, if you already ran the install script you will see the following line already in place in your `MainApplication` file:
 
 ```
-Embrace.getInstance().start(this)
+Embrace.start(this)
 ```
 
 Tweak the `onCreate` method using the following snippet to initialize the exporters with the minimum configuration needed.
+
+Embrace exposes two pairs of methods for registering custom exporters, depending on which OpenTelemetry API your exporters are built with:
+
+- `Embrace.addSpanExporter` / `Embrace.addLogRecordExporter` accept OpenTelemetry Kotlin exporters.
+- `Embrace.addJavaSpanExporter` / `Embrace.addJavaLogRecordExporter` accept OpenTelemetry Java exporters.
+
+The example below uses the OpenTelemetry Java exporters.
 
 Add the following imports:
 
@@ -178,11 +185,11 @@ val logExporter = OtlpHttpLogRecordExporter.builder()
                                 .setEndpoint("https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs")
                                 .addHeader("Authorization", "Basic __YOUR TOKEN__")
 
-Embrace.getInstance().addSpanExporter(spanExporter.build())
-Embrace.getInstance().addLogRecordExporter(logExporter.build())
+Embrace.addJavaSpanExporter(spanExporter.build())
+Embrace.addJavaLogRecordExporter(logExporter.build())
 
 // This is the line already added by the install script
-Embrace.getInstance().start(this)
+Embrace.start(this)
 ```
 
 ## Disable tracing for the OTLP export network requests

--- a/packages/react-native-otlp/android/dependencies.gradle
+++ b/packages/react-native-otlp/android/dependencies.gradle
@@ -7,6 +7,7 @@ def packageJsonFile = file("$packageJsonPath/package.json")
 def packageJson = json.parse(packageJsonFile)
 
 def embrace = "io.embrace:embrace-android-sdk:$packageJson.embrace.androidVersion"
+def embraceOtelJava = "io.embrace:embrace-android-otel-java:$packageJson.embrace.androidVersion"
 def opentelemetry = "io.opentelemetry:opentelemetry-exporter-otlp:1.43.0"
 
 // covering custom dependencies specific to Embrace and OpenTelemetry
@@ -14,9 +15,11 @@ dependencies {
   // if it is an app use `implementation` otherwise use the `api` annotation
   if (plugins.hasPlugin('com.android.application')) {
     implementation embrace
+    implementation embraceOtelJava
     implementation opentelemetry
   } else if (plugins.hasPlugin('com.android.library')) {
     api embrace
+    api embraceOtelJava
     api opentelemetry
   }
 }

--- a/packages/react-native-otlp/android/src/main/java/io/embrace/rnembraceotlp/RNEmbraceOTLPModule.kt
+++ b/packages/react-native-otlp/android/src/main/java/io/embrace/rnembraceotlp/RNEmbraceOTLPModule.kt
@@ -14,6 +14,9 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 
 import io.embrace.android.embracesdk.Embrace
+import io.embrace.android.embracesdk.otel.java.addJavaLogRecordExporter
+import io.embrace.android.embracesdk.otel.java.addJavaSpanExporter
+
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 
@@ -150,12 +153,12 @@ class RNEmbraceOTLPModule(reactContext: ReactApplicationContext) : ReactContextB
 
         if (spanConfig != null && spanConfig.endpoint.isNotBlank()) {
             val spanCustomExporter = setOtlpHttpTraceExporter(spanConfig.endpoint, spanConfig.headers, spanConfig.timeout)
-            Embrace.getInstance().addSpanExporter(spanCustomExporter)
+            Embrace.addJavaSpanExporter(spanCustomExporter)
         }
 
         if (logConfig != null && logConfig.endpoint.isNotBlank()) {
             val logCustomExporter = setOtlpHttpLogExporter(logConfig.endpoint, logConfig.headers, logConfig.timeout)
-            Embrace.getInstance().addLogRecordExporter(logCustomExporter)
+            Embrace.addJavaLogRecordExporter(logCustomExporter)
         }
     }
 
@@ -177,7 +180,7 @@ class RNEmbraceOTLPModule(reactContext: ReactApplicationContext) : ReactContextB
             }
 
             // 2) Embrace Start
-            Embrace.getInstance().start(this.context.getApplicationContext())
+            Embrace.start(this.context.getApplicationContext())
 
             promise.resolve(true)
         } catch (e: Exception) {

--- a/packages/react-native-otlp/test-project/android/app/build.gradle.kts
+++ b/packages/react-native-otlp/test-project/android/app/build.gradle.kts
@@ -126,12 +126,11 @@ dependencies {
 
     testImplementation(libs.junit)
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    testImplementation("junit:junit:4.12")
+    testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.3.1")
     testImplementation("io.mockk:mockk:1.13.11")
 
-    testImplementation("org.robolectric:robolectric:4.8")
+    testImplementation("org.robolectric:robolectric:4.15.1")
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/packages/react-native-otlp/test-project/android/app/src/test/java/io/embrace/rnembraceotlptest/RNEmbraceOTLPTest.kt
+++ b/packages/react-native-otlp/test-project/android/app/src/test/java/io/embrace/rnembraceotlptest/RNEmbraceOTLPTest.kt
@@ -10,7 +10,7 @@ import com.facebook.react.bridge.WritableMap
 import io.embrace.rnembraceotlp.RNEmbraceOTLPModule
 import org.junit.Before
 import org.junit.Test
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`

--- a/packages/react-native-otlp/test-project/android/app/src/test/java/io/embrace/rnembraceotlptest/RNEmbraceOTLPTest.kt
+++ b/packages/react-native-otlp/test-project/android/app/src/test/java/io/embrace/rnembraceotlptest/RNEmbraceOTLPTest.kt
@@ -8,9 +8,9 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import io.embrace.rnembraceotlp.RNEmbraceOTLPModule
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`


### PR DESCRIPTION
## Goal

Updates the react-native-otlp package for Android SDK v8.4.0.

The package now uses the `embrace-android-otel-java` compatibility module to add Java span and log exporters.

## Testing

Unit tests and manual testing
