### PR TITLE
[EMBR-12832] Move CI workflows to macos 26 / xcode 26.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-26') || 'ubuntu-latest' }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,9 +23,16 @@ jobs:
         test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
         platform: [android, ios]
 
-    runs-on: ${{ matrix.platform == 'ios' && 'macos-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.platform == 'ios' && 'macos-26' || 'ubuntu-latest' }}
 
     steps:
+      - name: Select Xcode
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        if: matrix.platform == 'ios'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -61,6 +61,11 @@ jobs:
 
       - name: Build Test App
         working-directory: ./integration-tests
+        env:
+          # macos-26 runner images ship a MetalToolchain overlay alongside Xcode 26.x whose Swift stdlib is missing
+          # swiftCompatibility libs, resulting in linker errors on older RN versions - so we override TOOLCHAINS to force xcodebuild
+          # back onto the default Xcode toolchain (see https://github.com/actions/runner-images/issues/13135)
+          TOOLCHAINS: com.apple.dt.toolchain.XcodeDefault
         run: ./build-test-app.sh ${{ matrix.test-app }} ${{ matrix.platform }} namespace-${{ matrix.test-app }}-${{ matrix.platform }}-${{ github.run_id }}
 
       - name: Run Integration Tests

--- a/.github/workflows/ios.unit-test.yml
+++ b/.github/workflows/ios.unit-test.yml
@@ -7,6 +7,12 @@ on:
         description: "Run tests for all packages, ignoring changed-file filters"
         type: boolean
         default: false
+  workflow_dispatch:
+    inputs:
+      run_all:
+        description: "Run tests for all packages, ignoring changed-file filters"
+        type: boolean
+        default: true
   push:
     branches: [main]
   pull_request:
@@ -17,8 +23,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
+      - name: Select Xcode
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+      
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -53,8 +65,14 @@ jobs:
         if: ${{ inputs.run_all || steps.changed_files.outputs.ios == 'true' }}
 
   test-core:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
+      - name: Select Xcode
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -133,8 +151,13 @@ jobs:
           du -sh ~/Library/Developer/Xcode/DerivedData || echo "DerivedData not found"
 
   test-tracer-provider:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
+      - name: Select Xcode
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -215,8 +238,13 @@ jobs:
   # excessive build times and memory pressure on free CI runners. Code coverage can be collected
   # locally where hardware resources are better. See scripts/run-ios-tests-no-coverage.sh
   test-otlp:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
+      - name: Select Xcode
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ios.unit-test.yml
+++ b/.github/workflows/ios.unit-test.yml
@@ -22,7 +22,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  build:
+  lint:
     runs-on: macos-26
     steps:
       - name: Select Xcode
@@ -55,6 +55,8 @@ jobs:
             - 'packages/**/*.m'
             - 'packages/**/*.h'
             - 'packages/**/test-project/ios/Podfile.lock'
+            - '.github/workflows/ios.unit-test.yml'
+            - 'scripts/run-swiftlint.sh'
 
       - name: Install Root Node Modules
         run: yarn install
@@ -97,6 +99,8 @@ jobs:
             - 'packages/core/**/*.m'
             - 'packages/core/**/*.h'
             - 'packages/core/test-project/ios/Podfile.lock'
+            - '.github/workflows/ios.unit-test.yml'
+            - 'scripts/run-ios-tests-no-coverage.sh'
 
       - name: Cache Derived Data
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -182,6 +186,8 @@ jobs:
             - 'packages/react-native-tracer-provider/**/*.m'
             - 'packages/react-native-tracer-provider/**/*.h'
             - 'packages/react-native-tracer-provider/test-project/ios/Podfile.lock'
+            - '.github/workflows/ios.unit-test.yml'
+            - 'scripts/run-ios-tests-no-coverage.sh'
 
       - name: Cache Derived Data
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -269,6 +275,8 @@ jobs:
             - 'packages/react-native-otlp/**/*.m'
             - 'packages/react-native-otlp/**/*.h'
             - 'packages/react-native-otlp/test-project/ios/Podfile.lock'
+            - '.github/workflows/ios.unit-test.yml'
+            - 'scripts/run-ios-tests-no-coverage.sh'
 
       - name: Cache Derived Data
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/update-native-sdks.yaml
+++ b/.github/workflows/update-native-sdks.yaml
@@ -15,7 +15,7 @@ jobs:
           - platform: "android"
             runner: "ubuntu-latest"
           - platform: "apple"
-            runner: "macos-latest"
+            runner: "macos-26"
     permissions:
       contents: write
       pull-requests: write

--- a/scripts/run-ios-tests-no-coverage.sh
+++ b/scripts/run-ios-tests-no-coverage.sh
@@ -2,6 +2,6 @@
 # Run iOS tests WITHOUT code coverage (used for memory-intensive packages like OTLP)
 WORKSPACE=$1
 SCHEME=$2
-# iPhone 16 Pro with iOS 18.5 - available on both local and CI environments
-xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' -disable-concurrent-testing -jobs 1 | xcbeautify
+# iPhone 17 Pro with iOS 26.5 - available on both local and CI environments
+xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -disable-concurrent-testing -jobs 1 | xcbeautify
 exit  "${PIPESTATUS[0]}"

--- a/scripts/run-ios-tests.sh
+++ b/scripts/run-ios-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 WORKSPACE=$1
 SCHEME=$2
-# iPhone 16 Pro with iOS 18.5 - available on both local and CI environments
-xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator -enableCodeCoverage YES -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' -disable-concurrent-testing -jobs 1 | xcbeautify
+# iPhone 17 Pro with iOS 26.5 - available on both local and CI environments
+xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk iphonesimulator -enableCodeCoverage YES -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -disable-concurrent-testing -jobs 1 | xcbeautify
 exit  "${PIPESTATUS[0]}"


### PR DESCRIPTION
## Goal

CI runs began failing as the `macos-latest` label is being updated from macos-15 to macos-26 and our workflows assume macos-15: https://github.com/actions/runner-images/issues/14167

This PR updates the workflows for macos 26 and pins runners to the explicit `macos-26` label instead of the floating `macos-latest`:
- Xcode version is pinned to 26.3 since RN is incompatible with Xcode 26.4+ (clang compiler errors)
- iOS unit tests now run against `iPhone 17 Pro, OS=26.5` as this is readily available both in CI and locally.

Also made some minor improvements to the iOS unit test workflow:
- updated the change detection to include the workflow file and relevant scripts, so changes to either will trigger a CI run
- added a workflow_dispatch trigger so tests can be run manually

## Testing

Manual runs of both the unit test and integration test workflows confirmed all builds are passing

