### PR TITLE
[EMBR-12894] Split integration tests into per-platform build/test jobs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,11 +21,12 @@ permissions:
   pull-requests: read
 
 jobs:
-  gate:
+  prepare:
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.decide.outputs.android }}
       ios: ${{ steps.decide.outputs.ios }}
+      matrix: ${{ steps.decide.outputs.matrix }}
     steps:
       - id: decide
         env:
@@ -42,14 +43,15 @@ jobs:
           fi
           echo "android=$android" >> "$GITHUB_OUTPUT"
           echo "ios=$ios" >> "$GITHUB_OUTPUT"
+          echo 'matrix=["expo-rn74","rn82","rn81","rn80","rn79","rn78","rn77","rn76","rn75","rn74","rn73","rn72","rn71"]' >> "$GITHUB_OUTPUT"
 
   build-android:
-    needs: gate
-    if: ${{ needs.gate.outputs.android == 'true' }}
+    needs: prepare
+    if: ${{ needs.prepare.outputs.android == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
+        test-app: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     runs-on: ubuntu-latest
 
@@ -92,12 +94,12 @@ jobs:
           retention-days: 1
 
   build-ios:
-    needs: gate
-    if: ${{ needs.gate.outputs.ios == 'true' }}
+    needs: prepare
+    if: ${{ needs.prepare.outputs.ios == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
+        test-app: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     runs-on: macos-26
 
@@ -146,13 +148,13 @@ jobs:
           retention-days: 1
 
   test-android:
-    needs: [gate, build-android]
-    if: ${{ !cancelled() && needs.gate.outputs.android == 'true' }}
+    needs: [prepare, build-android]
+    if: ${{ !cancelled() && needs.prepare.outputs.android == 'true' }}
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
+        test-app: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     runs-on: ubuntu-latest
 
@@ -189,13 +191,13 @@ jobs:
           CI_GIT_REF: ${{ github.ref_name }}
 
   test-ios:
-    needs: [gate, build-ios]
-    if: ${{ !cancelled() && needs.gate.outputs.ios == 'true' }}
+    needs: [prepare, build-ios]
+    if: ${{ !cancelled() && needs.prepare.outputs.ios == 'true' }}
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
+        test-app: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
     # The remote run only drives BrowserStack over HTTP, so no macOS is needed.
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,6 +8,12 @@ on:
       BROWSERSTACK_ACCESS_KEY:
         required: true
   workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform(s) to test"
+        type: choice
+        options: [both, android, ios]
+        default: both
   pull_request:
 
 permissions:
@@ -15,8 +21,31 @@ permissions:
   pull-requests: read
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.decide.outputs.android }}
+      ios: ${{ steps.decide.outputs.ios }}
+    steps:
+      - id: decide
+        env:
+          # empty for any trigger other than workflow_dispatch, which the default below treats as "both"
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          run=${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/') }}
+          platform="${PLATFORM:-both}"
+          android=false
+          ios=false
+          if [ "$run" = "true" ]; then
+            if [ "$platform" = "both" ] || [ "$platform" = "android" ]; then android=true; fi
+            if [ "$platform" = "both" ] || [ "$platform" = "ios" ]; then ios=true; fi
+          fi
+          echo "android=$android" >> "$GITHUB_OUTPUT"
+          echo "ios=$ios" >> "$GITHUB_OUTPUT"
+
   build-android:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/') }}
+    needs: gate
+    if: ${{ needs.gate.outputs.android == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +92,8 @@ jobs:
           retention-days: 1
 
   build-ios:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/') }}
+    needs: gate
+    if: ${{ needs.gate.outputs.ios == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -116,8 +146,8 @@ jobs:
           retention-days: 1
 
   test-android:
-    needs: build-android
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/')) }}
+    needs: [gate, build-android]
+    if: ${{ !cancelled() && needs.gate.outputs.android == 'true' }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -159,8 +189,8 @@ jobs:
           CI_GIT_REF: ${{ github.ref_name }}
 
   test-ios:
-    needs: build-ios
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/')) }}
+    needs: [gate, build-ios]
+    if: ${{ !cancelled() && needs.gate.outputs.ios == 'true' }}
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,24 +15,16 @@ permissions:
   pull-requests: read
 
 jobs:
-  build:
+  build-android:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/') }}
     strategy:
       fail-fast: false
       matrix:
         test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
-        platform: [android, ios]
 
-    runs-on: ${{ matrix.platform == 'ios' && 'macos-26' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Select Xcode
-        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
-        if: matrix.platform == 'ios'
-        run: |
-          sudo xcode-select -s /Applications/Xcode_26.3.app
-          xcodebuild -version
-
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -53,7 +45,54 @@ jobs:
         with:
           distribution: "adopt"
           java-version-file: ".java-version"
-        if: matrix.platform == 'android'
+
+      - name: Install Integration Tests Node Modules
+        working-directory: ./integration-tests
+        run: npm install
+
+      - name: Build Test App
+        working-directory: ./integration-tests
+        run: ./build-test-app.sh ${{ matrix.test-app }} android namespace-${{ matrix.test-app }}-android-${{ github.run_id }}
+
+      - name: Upload app artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: app-${{ matrix.test-app }}-android
+          path: integration-tests/${{ matrix.test-app }}.apk
+          if-no-files-found: error
+          retention-days: 1
+
+  build-ios:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
+
+    runs-on: macos-26
+
+    steps:
+      - name: Select Xcode
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - name: Enables corepack
+        run: corepack enable
+
+      - name: Install Root Node Modules
+        run: yarn install
 
       - name: Install Integration Tests Node Modules
         working-directory: ./integration-tests
@@ -66,29 +105,67 @@ jobs:
           # swiftCompatibility libs, resulting in linker errors on older RN versions - so we override TOOLCHAINS to force xcodebuild
           # back onto the default Xcode toolchain (see https://github.com/actions/runner-images/issues/13135)
           TOOLCHAINS: com.apple.dt.toolchain.XcodeDefault
-        run: ./build-test-app.sh ${{ matrix.test-app }} ${{ matrix.platform }} namespace-${{ matrix.test-app }}-${{ matrix.platform }}-${{ github.run_id }}
+        run: ./build-test-app.sh ${{ matrix.test-app }} ios namespace-${{ matrix.test-app }}-ios-${{ github.run_id }}
 
       - name: Upload app artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: app-${{ matrix.test-app }}-${{ matrix.platform }}
-          path: integration-tests/${{ matrix.test-app }}.${{ matrix.platform == 'ios' && 'ipa' || 'apk' }}
+          name: app-${{ matrix.test-app }}-ios
+          path: integration-tests/${{ matrix.test-app }}.ipa
           if-no-files-found: error
           retention-days: 1
 
-  # Builds above run fully in parallel, but our BrowserStack plan only allows 1
-  # parallel session, so the test phase is throttled to keep at most ~2 sessions
-  # in flight (max-parallel: 1 job x 2 devices). This keeps queue waits under
-  # connectionRetryTimeout and avoids BROWSERSTACK_QUEUE_SIZE_EXCEEDED.
-  test:
-    needs: build
+  test-android:
+    needs: build-android
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/')) }}
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
         test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
-        platform: [android, ios]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - name: Install Integration Tests Node Modules
+        working-directory: ./integration-tests
+        run: npm install
+
+      - name: Download app artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: app-${{ matrix.test-app }}-android
+          path: integration-tests/
+
+      - name: Run Integration Tests
+        working-directory: ./integration-tests
+        run: npm run test-remote
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_APP_NAME: ${{ matrix.test-app }}
+          BROWSERSTACK_PLATFORM: android
+          CI_RUN_ID: ${{ github.ref_name }}.${{ github.sha }}
+          CI_GIT_REF: ${{ github.ref_name }}
+
+  test-ios:
+    needs: build-ios
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/')) }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
 
     # The remote run only drives BrowserStack over HTTP, so no macOS is needed.
     runs-on: ubuntu-latest
@@ -111,7 +188,7 @@ jobs:
       - name: Download app artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: app-${{ matrix.test-app }}-${{ matrix.platform }}
+          name: app-${{ matrix.test-app }}-ios
           path: integration-tests/
 
       - name: Run Integration Tests
@@ -121,6 +198,6 @@ jobs:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_APP_NAME: ${{ matrix.test-app }}
-          BROWSERSTACK_PLATFORM: ${{ matrix.platform }}
+          BROWSERSTACK_PLATFORM: ios
           CI_RUN_ID: ${{ github.ref_name }}.${{ github.sha }}
           CI_GIT_REF: ${{ github.ref_name }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -68,6 +68,52 @@ jobs:
           TOOLCHAINS: com.apple.dt.toolchain.XcodeDefault
         run: ./build-test-app.sh ${{ matrix.test-app }} ${{ matrix.platform }} namespace-${{ matrix.test-app }}-${{ matrix.platform }}-${{ github.run_id }}
 
+      - name: Upload app artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: app-${{ matrix.test-app }}-${{ matrix.platform }}
+          path: integration-tests/${{ matrix.test-app }}.${{ matrix.platform == 'ios' && 'ipa' || 'apk' }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Builds above run fully in parallel, but our BrowserStack plan only allows 1
+  # parallel session, so the test phase is throttled to keep at most ~2 sessions
+  # in flight (max-parallel: 1 job x 2 devices). This keeps queue waits under
+  # connectionRetryTimeout and avoids BROWSERSTACK_QUEUE_SIZE_EXCEEDED.
+  test:
+    needs: build
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'embrace-ci/')) }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        test-app: [expo-rn74, rn82, rn81, rn80, rn79, rn78, rn77, rn76, rn75, rn74, rn73, rn72, rn71]
+        platform: [android, ios]
+
+    # The remote run only drives BrowserStack over HTTP, so no macOS is needed.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - name: Install Integration Tests Node Modules
+        working-directory: ./integration-tests
+        run: npm install
+
+      - name: Download app artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: app-${{ matrix.test-app }}-${{ matrix.platform }}
+          path: integration-tests/
+
       - name: Run Integration Tests
         working-directory: ./integration-tests
         run: npm run test-remote

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -83,7 +83,10 @@ jobs:
 
       - name: Build Test App
         working-directory: ./integration-tests
-        run: ./build-test-app.sh ${{ matrix.test-app }} android namespace-${{ matrix.test-app }}-android-${{ github.run_id }}
+        env:
+          TEST_APP: ${{ matrix.test-app }}
+          RUN_ID: ${{ github.run_id }}
+        run: ./build-test-app.sh "$TEST_APP" android "namespace-$TEST_APP-android-$RUN_ID"
 
       - name: Upload app artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -137,7 +140,9 @@ jobs:
           # swiftCompatibility libs, resulting in linker errors on older RN versions - so we override TOOLCHAINS to force xcodebuild
           # back onto the default Xcode toolchain (see https://github.com/actions/runner-images/issues/13135)
           TOOLCHAINS: com.apple.dt.toolchain.XcodeDefault
-        run: ./build-test-app.sh ${{ matrix.test-app }} ios namespace-${{ matrix.test-app }}-ios-${{ github.run_id }}
+          TEST_APP: ${{ matrix.test-app }}
+          RUN_ID: ${{ github.run_id }}
+        run: ./build-test-app.sh "$TEST_APP" ios "namespace-$TEST_APP-ios-$RUN_ID"
 
       - name: Upload app artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/integration-tests/browserstack.conf.ts
+++ b/integration-tests/browserstack.conf.ts
@@ -74,7 +74,8 @@ exports.config = {
     },
   },
 
-  maxInstances: 10,
+  // Run workers sequentially
+  maxInstances: 1,
 
   updateJob: false,
   specs: ["./specs/simple.test.ts"], // TODO EMBR-4922 point to full test suite
@@ -87,7 +88,8 @@ exports.config = {
   waitforTimeout: 10000,
   // wdio v9 enforces this as a hard abort on session creation (got->fetch); a
   // timed-out newSession is no longer retried, so give BrowserStack room to allocate.
-  connectionRetryTimeout: 300000,
+  // 15 minutes to match browserstack's session timeout - this is the max time a session can be queued before it is aborted.
+  connectionRetryTimeout: 900000,
   connectionRetryCount: 3,
 
   framework: "mocha",

--- a/integration-tests/browserstack.conf.ts
+++ b/integration-tests/browserstack.conf.ts
@@ -105,20 +105,12 @@ exports.config.capabilities.forEach(function (caps) {
     caps[key] = { ...caps[key], ...exports.config.commonCapabilities[key] };
 });
 
-/*
-  Dealing w/ BrowserStack throwing BROWSERSTACK_QUEUE_SIZE_EXCEEDED. Per our plan we are only allowed a certain
-  number of tests running in parallel + waiting in queue to be run. If we exceed this browserstack responds with an
-  error when the session is trying to be setup and the suite fails.
-  To help mitigate:
-     1) Before spinning up a new worker check how many are already queued and wait if we're at the max
-     2) Up specFileRetries + specFileRetriesDelay in case we still get a collision on the last slot
- */
-
 // The number of times to retry the entire specfile when it fails as a whole
 exports.config.specFileRetries = 2;
 
-// Delay in seconds between the spec file retry attempts
-exports.config.specFileRetriesDelay = 60;
+// Delay in seconds between the spec file retry attempts.
+// Low on purpose as wdio also applies it as a pre-start sleep before spawning workers
+exports.config.specFileRetriesDelay = 5;
 
 // https://www.browserstack.com/docs/app-automate/api-reference/appium/plan#get-plan-details
 interface BrowserStackPlanDetails {
@@ -132,7 +124,6 @@ const browserStackBasicAuth = Buffer.from(
 
 const QUEUE_FULL_DELAY_SECONDS = 180;
 const QUEUE_FULL_RETRIES = 5;
-const QUEUE_JITTER_SECONDS = 10;
 
 /**
  * Gets executed before a worker process is spawned and can be used to initialize specific service
@@ -144,13 +135,11 @@ const QUEUE_JITTER_SECONDS = 10;
  * @param  {object} execArgv list of string arguments passed to the worker process
  */
 exports.config.onWorkerStart = async () => {
+  // Dealing w/ BrowserStack throwing BROWSERSTACK_QUEUE_SIZE_EXCEEDED. Per our plan we are only allowed a certain
+  // number of tests running in parallel + waiting in queue to be run. If we exceed this browserstack responds with an
+  // error when the session is trying to be setup and the suite fails.
+  // To help mitigate, before spinning up a new worker check how many are already queued and wait if we're at the max
   let retries = 0;
-
-  // Add some randomness around checking the queue size to deal with multiple workers claiming the same slot
-  await new Promise(r =>
-    setTimeout(r, QUEUE_JITTER_SECONDS * 1000 * Math.random()),
-  );
-
   while (true) {
     const queueSlots = await getQueueSlots();
     if (queueSlots > 0) {


### PR DESCRIPTION
## Goal

Restructures the integration-test workflow so tests run more reliably on BrowserStack while keeping builds as fast as possible. 

Previously we were firing all test runs in parallel (or whenever the build step succeeded) and relying on wdio retrying requests + the `onWorkerStart` hook to mitigate the limited number of available browserstack slots. Despite that mitigation, we've been seeing lots of test runs failing due to session creation requests timing out and `BROWSERSTACK_QUEUE_SIZE_EXCEEDED` errors.

It looks like the situation got worse after the upgrade to wdio v9, which no longer retries timeouts in session creation requests. After `connectionRetryTimeout` elapses wdio just aborts and errors out, so it no longer recovers by itself.

The fix caps the number of in-flight sessions upfront to what our plan can handle, and decouples test runs from the build phase so that tests can be retried without having to re-build the test fixture. 

This greatly reduces the likelihood of tests failing due to request timeouts and queue size limits, and since BS slots are limited anyway it doesn't really affect overall test run times - it just shifts the bottleneck to somewhere we can better control. If the number of slots is ever increased, we have a clear knob to turn to increase concurrency (`max-parallel` in the workflow and `maxInstances` in the wdio config).

## Changes

## Workflow (`integration-test.yml`)
- Split the single build+test job into separate **build** and **test** jobs, per platform:
  `build-android`, `build-ios`, `test-android`, `test-ios`.
- Builds run fully in parallel as before and upload the test app as an artifact that the test jobs then download. This keeps fixture builds fast and isolates the bottleneck to the actual test jobs.
- Each test job is `max-parallel: 1`, which keeps max 2 sessions in flight (1 per platform)
- Added a single `gate` job that computes the run condition once (per platform), removing the
  duplicated `if:` across jobs.
- Added a `platform` input (`both` | `android` | `ios`) to the manual trigger to support manual runs for a single platform. All other triggers run both platforms.

## wdio config (`browserstack.conf.ts`)
- Reduced `maxInstances` to 1 since we can only run 1 session at a time anyway.
- Upped `connectionRetryTimeout` to 15 mins, matching BrowserStack's 15-min server-side queue hold,
  so a queued session isn't aborted early (wdio v9 makes this a hard, non-retried abort).
- Reduced `specFileRetriesDelay` to 5s - we shouldn't see `BROWSERSTACK_QUEUE_SIZE_EXCEEDED` errors any more, and it just slowed test runs down unnecessarily (turns out wdio now applies this as a pre-start sleep before every worker, not just when a spec file fails).
- Removed the queue-check jitter (unnecessary now that workers run sequentially and max 2 sessions are ever in flight).

## Testing

Tested with a manual workflow trigger
