### PR TITLE
[EMBR-13725] Remove unreachable EmbraceIO pod patch from setup scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.11",
     "@types/react-native": "^0.60.2",
-    "@types/semver": "^7.1.0",
     "@yarnpkg/types": "^4.0.0",
     "babel-jest": "^30.0.4",
     "eslint": "^10.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "glob": "^13.0.6",
     "inquirer": "^12.0.0",
-    "semver": "^7.1.3",
     "xcode": "^3.0.1"
   },
   "peerDependencies": {

--- a/packages/core/scripts/__tests__/install.ios.test.ts
+++ b/packages/core/scripts/__tests__/install.ios.test.ts
@@ -112,28 +112,4 @@ describe("Install Script iOS", () => {
     );
     expect(afterRemoval.toString()).toEqual(mockWithoutEmbrace.toString());
   });
-
-  test("Patch Podfile", async () => {
-    jest.mock("glob", () => ({
-      sync: () => [
-        "./packages/core/scripts/__tests__/__mocks__/ios/PodfileWithoutEmbrace",
-      ],
-    }));
-    jest.mock("semver/functions/gte", () => () => false);
-
-    const {patchPodfile} = require("../setup/ios");
-    const mockPackageJson = {
-      name: "Test",
-      dependencies: {
-        "react-native": "0.0.0",
-      },
-    };
-    await patchPodfile(mockPackageJson);
-
-    const {removeEmbraceLinkFromFile} = require("../setup/uninstall");
-
-    const resultUnpatch = await removeEmbraceLinkFromFile("podFileImport");
-
-    expect(resultUnpatch).toBe(true);
-  });
 });

--- a/packages/core/scripts/__tests__/uninstall.ios.test.ts
+++ b/packages/core/scripts/__tests__/uninstall.ios.test.ts
@@ -40,36 +40,6 @@ describe("Uninstall Script iOS", () => {
     .spyOn(Wizard.prototype, "fieldValueList")
     .mockResolvedValueOnce(["t3st4", {name: "io.embrace.testapp"}]);
 
-  test("Remove Embrace From Podfile", async () => {
-    jest.mock("glob", () => ({
-      sync: () => ["./packages/core/scripts/__tests__/__mocks__/ios/Podfile"],
-    }));
-
-    jest.mock("semver/functions/gte", () => () => false);
-    jest.mock(
-      "../../../../../../package.json",
-      () => ({
-        name: "test",
-      }),
-      {virtual: true},
-    );
-    const {removeEmbraceLinkFromFile} = require("../setup/uninstall");
-
-    const resultUnpatch = await removeEmbraceLinkFromFile("podFileImport");
-
-    expect(resultUnpatch).toBe(true);
-
-    const {patchPodfile} = require("../setup/ios");
-    const mockPackageJson = {
-      name: "Test",
-      dependencies: {
-        "react-native": "0.0.0",
-      },
-    };
-
-    await patchPodfile(mockPackageJson);
-  });
-
   test("Remove KSCrash from Podfile", async () => {
     const podfile = "./packages/core/scripts/__tests__/tmp/PodfileKSCrash";
     copyMock(
@@ -81,7 +51,6 @@ describe("Uninstall Script iOS", () => {
       sync: () => ["./packages/core/scripts/__tests__/tmp/PodfileKSCrash"],
     }));
 
-    jest.mock("semver/functions/gte", () => () => false);
     jest.mock(
       "../../../../../../package.json",
       () => ({

--- a/packages/core/scripts/setup/README.md
+++ b/packages/core/scripts/setup/README.md
@@ -13,7 +13,6 @@ That `run` function will register `iosAppID`, `apiToken` and `iosProjectFolderNa
 The setup script for iOS includes:
 - `addEmbraceInitializerSwift`: Adds `EmbraceInitializer.swift` to the project which includes the code for setting up and starting the iOS SDK.
 - `iosInitializeEmbrace`: It patches the AppDelegate m|mm or swift to call the start method from `EmbraceInitializer.swift`.
-- `iOSPodfilePatch`: It patches the Podfile, only in < 0.6 adding the dependency. This is useful if the app does not have autolink for some reason.
 - `patchXcodeBundlePhase`: It patches the `Bundle React Native code and images` created by React Native, adding a line to export the sourcemap to a desired path.
 - `addUploadBuildPhase`: It adds the `Upload Debug Symbols to Embrace` to the build phase.
 

--- a/packages/core/scripts/setup/common.ts
+++ b/packages/core/scripts/setup/common.ts
@@ -1,10 +1,5 @@
 import Asker, {Answer} from "../util/asker";
 
-interface IPackageJson {
-  name: string;
-  dependencies: Record<string, string>;
-}
-
 enum Platform {
   Android = "Android",
   IOS = "iOS",
@@ -87,7 +82,6 @@ const packageJSON = {
 };
 
 export {
-  IPackageJson,
   Platform,
   iosAppID,
   androidAppID,

--- a/packages/core/scripts/setup/ios.ts
+++ b/packages/core/scripts/setup/ios.ts
@@ -2,10 +2,8 @@
 import Wizard from "../util/wizard";
 import {
   BUNDLE_PHASE_REGEXP,
-  EMBR_NATIVE_POD,
   EMBR_RUN_SCRIPT,
   EXPORT_SOURCEMAP_RN_VAR,
-  podfilePatchable,
   xcodePatchable,
   findNameWithCaseSensitiveFromPath,
   MKDIR_SOURCEMAP_DIR,
@@ -15,18 +13,10 @@ import {
 import EmbraceLogger from "../../src/utils/EmbraceLogger";
 
 import patch from "./patches/patch";
-import {
-  apiToken,
-  iosAppID,
-  iosProjectFolderName,
-  IPackageJson,
-  packageJSON,
-} from "./common";
+import {apiToken, iosAppID, iosProjectFolderName, packageJSON} from "./common";
 
 const path = require("path");
 const fs = require("fs");
-
-const semverGte = require("semver/functions/gte");
 
 const LOGGER = new EmbraceLogger(console);
 
@@ -66,45 +56,6 @@ const iosInitializeEmbrace = {
   },
   docURL:
     "https://embrace.io/docs/react-native/integration/add-embrace-sdk/?platform=ios#manually",
-};
-
-const patchPodfile = (json: IPackageJson) => {
-  const rnVersion = (json.dependencies || {})["react-native"];
-
-  if (!rnVersion) {
-    throw Error("react-native dependency was not found");
-  }
-
-  const rnVersionSanitized = rnVersion.replace("^", "");
-
-  // If 6.0.0, autolink should have linked the Pod.
-  if (semverGte("6.0.0", rnVersionSanitized)) {
-    LOGGER.log(
-      "Skipping patching Podfile since react-native is on an autolink supported version",
-    );
-
-    return;
-  }
-
-  return podfilePatchable().then(podfile => {
-    if (podfile.hasLine(EMBR_NATIVE_POD)) {
-      LOGGER.warn("Already has 'EmbraceIO' pod");
-      return;
-    }
-
-    podfile.addBefore("use_react_native", `${EMBR_NATIVE_POD}\n`);
-
-    return podfile.patch();
-  });
-};
-
-const iOSPodfilePatch = {
-  name: "Podfile patch (Only React Native v < 0.6)",
-  run: async (wizard: Wizard): Promise<any> => {
-    return wizard.fieldValue(packageJSON).then(patchPodfile);
-  },
-  docURL:
-    "https://embrace.io/docs/react-native/integration/add-embrace-sdk/?platform=ios#native-modules",
 };
 
 const patchXcodeBundlePhase = {
@@ -241,10 +192,8 @@ import EmbraceIO
 
 export {
   tryToPatchAppDelegate,
-  patchPodfile,
   getIOSProjectName,
   iosInitializeEmbrace,
-  iOSPodfilePatch,
   patchXcodeBundlePhase,
   addUploadBuildPhase,
   addEmbraceInitializerSwift,

--- a/packages/core/scripts/setup/setupIos.ts
+++ b/packages/core/scripts/setup/setupIos.ts
@@ -5,7 +5,6 @@ import {
   addUploadBuildPhase,
   addEmbraceInitializerSwift,
   iosInitializeEmbrace,
-  iOSPodfilePatch,
   patchXcodeBundlePhase,
 } from "./ios";
 import {apiToken, iosAppID, iosProjectFolderName, packageJSON} from "./common";
@@ -20,7 +19,6 @@ const IOS_REGISTER_FIELDS = [
 const IOS_STEPS = [
   addEmbraceInitializerSwift,
   iosInitializeEmbrace,
-  iOSPodfilePatch,
   patchXcodeBundlePhase,
   addUploadBuildPhase,
 ];

--- a/packages/core/scripts/setup/uninstall.ts
+++ b/packages/core/scripts/setup/uninstall.ts
@@ -2,7 +2,6 @@ import Wizard, {Step} from "../util/wizard";
 import {
   BUNDLE_PHASE_REGEXP,
   EMBR_KSCRASH_MODULAR_HEADER_POD,
-  EMBR_NATIVE_POD,
   EMBR_RUN_SCRIPT,
   embracePlistPatchable,
   EXPORT_SOURCEMAP_RN_VAR,
@@ -86,18 +85,6 @@ const UNINSTALL_ANDROID_GRADLE_PLUGIN_APPLY: IUnlinkEmbraceCode = {
   docUrl: "",
 };
 
-const UNINSTALL_IOS_PODFILE: IUnlinkEmbraceCode = {
-  stepName: "Removing Embrace code in Podfile",
-  fileName: "Podfile",
-  textsToDelete: [
-    {
-      ITextToDelete: `${EMBR_NATIVE_POD}\n`,
-    },
-  ],
-  findFileFunction: getPodFile,
-  docUrl: "",
-};
-
 // Only applies to projects patched by a version that still added this pod
 const UNINSTALL_IOS_KSCRASH_PODFILE: IUnlinkEmbraceCode = {
   stepName: "Removing KSCrash pod from Podfile",
@@ -112,10 +99,7 @@ const UNINSTALL_IOS_KSCRASH_PODFILE: IUnlinkEmbraceCode = {
 };
 
 type UNLINK_EMBRACE_CODE =
-  | "gradlePluginDependency"
-  | "gradlePluginApply"
-  | "podFileImport"
-  | "ksCrashPodImport";
+  "gradlePluginDependency" | "gradlePluginApply" | "ksCrashPodImport";
 
 type SupportedPatches = {
   [key in UNLINK_EMBRACE_CODE]: IUnlinkEmbraceCode;
@@ -124,7 +108,6 @@ type SupportedPatches = {
 const UNLINK_EMBRACE_CODE: SupportedPatches = {
   gradlePluginDependency: UNINSTALL_ANDROID_GRADLE_PLUGIN_DEPENDENCY,
   gradlePluginApply: UNINSTALL_ANDROID_GRADLE_PLUGIN_APPLY,
-  podFileImport: UNINSTALL_IOS_PODFILE,
   ksCrashPodImport: UNINSTALL_IOS_KSCRASH_PODFILE,
 };
 

--- a/packages/core/scripts/util/ios.ts
+++ b/packages/core/scripts/util/ios.ts
@@ -18,7 +18,6 @@ const UPLOAD_SYMBOLS_PHASE = "Embrace Symbol Uploads";
 const EMBRACE_INIT_OBJECTIVEC = "[EmbraceInitializer start];";
 const EMBR_RUN_SCRIPT =
   '"${SRCROOT}/../node_modules/@embrace-io/react-native/ios/scripts/run.sh"';
-const EMBR_NATIVE_POD = `pod 'EmbraceIO'`;
 // No longer added to Podfiles, KSCrash sets DEFINES_MODULE itself as of 2.5.0.
 // Kept so uninstall can still remove it from projects patched by older versions.
 const EMBR_KSCRASH_MODULAR_HEADER_POD = `
@@ -450,7 +449,6 @@ const findNameWithCaseSensitiveFromPath = (path: string, name: string) => {
 
 export {
   type ProjectFileType,
-  EMBR_NATIVE_POD,
   EMBR_KSCRASH_MODULAR_HEADER_POD,
   BUNDLE_PHASE_REGEXP,
   MKDIR_SOURCEMAP_DIR,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,7 +1614,6 @@ __metadata:
     expo: "npm:^56.0.9"
     glob: "npm:^13.0.6"
     inquirer: "npm:^12.0.0"
-    semver: "npm:^7.1.3"
     typescript: "npm:^5.6.3"
     xcode: "npm:^3.0.1"
   peerDependencies:
@@ -4308,13 +4307,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.1.0":
-  version: 7.7.0
-  resolution: "@types/semver@npm:7.7.0"
-  checksum: 10c0/6b5f65f647474338abbd6ee91a6bbab434662ddb8fe39464edcbcfc96484d388baad9eb506dff217b6fc1727a88894930eb1f308617161ac0f376fe06be4e1ee
-  languageName: node
-  linkType: hard
-
 "@types/stack-utils@npm:^2.0.3":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -6596,7 +6588,6 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.0.11"
     "@types/react-native": "npm:^0.60.2"
-    "@types/semver": "npm:^7.1.0"
     "@yarnpkg/types": "npm:^4.0.0"
     babel-jest: "npm:^30.0.4"
     eslint: "npm:^10.5.0"


### PR DESCRIPTION
## Goal

`iOSPodfilePatch` was intended to add `pod 'EmbraceIO'` to the Podfile for React Native versions predating autolinking (below 0.60.0). In reality it has never done so, because its version gate is inverted and has a typo:

```js
// If 6.0.0, autolink should have linked the Pod.
if (semverGte("6.0.0", rnVersionSanitized)) { /* skip */ }
```

`semver.gte(a, b)` is `a >= b`, so this asks "6.0.0" >= rnVersion, which is always true. So the step has always just logged "Skipping patching Podfile…" and returned.

This removes the step and everything that only it used, including the uninstall code since the patch could never have been added.

Also means we can remove the the `semver` dependency from the core package.

## Testing

Covered by unit tests.

