### PR TITLE
ci: switch to temurin java distro in CI workflows

### DIFF
--- a/.github/workflows/android.unit-test.yml
+++ b/.github/workflows/android.unit-test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         if: ${{ inputs.run_all || steps.changed_files.outputs.android == 'true' }}
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version-file: ".java-version"
 
       - name: Run Android Unit Tests (changed scopes)

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version-file: ".java-version"
 
       - name: Install Integration Tests Node Modules


### PR DESCRIPTION
## Goal

Switches the CI workflows from the `adopt` Java distro to `temurin` as `adopt` was removed in v6 of the setup-java action.

